### PR TITLE
[DDO-2504] Tweak changeset plan button text

### DIFF
--- a/app/routes/__layout/charts/$chartName/chart-releases/$chartReleaseName/change-versions.tsx
+++ b/app/routes/__layout/charts/$chartName/chart-releases/$chartReleaseName/change-versions.tsx
@@ -478,7 +478,7 @@ const ChangeVersionsRoute: React.FunctionComponent = () => {
       <OutsetPanel>
         <ActionBox
           title="Now Changing Versions"
-          submitText="Click to Calculate and Preview"
+          submitText="Click to Refresh and Preview Changes"
           {...ChartReleaseColors}
         >
           {preconfigured || (

--- a/app/routes/__layout/clusters/$clusterName/chart-releases/$namespace.$chartName/change-versions.tsx
+++ b/app/routes/__layout/clusters/$clusterName/chart-releases/$namespace.$chartName/change-versions.tsx
@@ -478,7 +478,7 @@ const ChangeVersionsRoute: React.FunctionComponent = () => {
       <OutsetPanel>
         <ActionBox
           title="Now Changing Versions"
-          submitText="Click to Calculate and Preview"
+          submitText="Click to Refresh and Preview Changes"
           {...ChartReleaseColors}
         >
           {preconfigured || (

--- a/app/routes/__layout/environments/$environmentName/change-versions.tsx
+++ b/app/routes/__layout/environments/$environmentName/change-versions.tsx
@@ -290,7 +290,7 @@ const ChangeVersionsRoute: React.FunctionComponent = () => {
       <OutsetPanel>
         <ActionBox
           title="Now Changing Versions"
-          submitText="Click to Calculate and Preview"
+          submitText="Click to Refresh and Preview Changes"
           {...EnvironmentColors}
         >
           <label>

--- a/app/routes/__layout/environments/$environmentName/chart-releases/$chartName/change-versions.tsx
+++ b/app/routes/__layout/environments/$environmentName/chart-releases/$chartName/change-versions.tsx
@@ -488,7 +488,7 @@ const ChangeVersionsRoute: React.FunctionComponent = () => {
       <OutsetPanel>
         <ActionBox
           title="Now Changing Versions"
-          submitText="Click to Calculate and Preview"
+          submitText="Click to Refresh and Preview Changes"
           {...ChartReleaseColors}
         >
           {preconfiguredVersions || (


### PR DESCRIPTION
With the #33 I use the word "refresh" more so I want to name the button the same. I'm also able to make this change due to the dark mode update, interestingly enough, because I refactored buttons to support multiple lines of text (so it being slightly longer doesn't cause it to break on small screens now)