### PR TITLE
[DDO-2534] Expose environment description

### DIFF
--- a/app/components/content/app-version/app-version-details.tsx
+++ b/app/components/content/app-version/app-version-details.tsx
@@ -1,12 +1,13 @@
 import { V2controllersAppVersion } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
 import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
-import { PrettyPrintVersionDescription } from "~/components/logic/pretty-print-version-description";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import { MutateControls } from "../helpers";
 import { AppVersionColors } from "./app-version-colors";
+import { SerializeFrom } from "@remix-run/node";
 
 export interface AppVersionDetailsProps {
-  appVersion: V2controllersAppVersion;
+  appVersion: V2controllersAppVersion | SerializeFrom<V2controllersAppVersion>;
   toEdit?: string;
 }
 
@@ -43,7 +44,7 @@ export const AppVersionDetails: React.FunctionComponent<
     <p>
       Description:{" "}
       {appVersion.description ? (
-        <PrettyPrintVersionDescription
+        <PrettyPrintDescription
           description={appVersion.description}
           repo={appVersion.chartInfo?.appImageGitRepo}
         />

--- a/app/components/content/app-version/app-version-editable-fields.tsx
+++ b/app/components/content/app-version/app-version-editable-fields.tsx
@@ -1,10 +1,11 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersAppVersion } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { TextAreaField } from "~/components/interactivity/text-area-field";
-import { PrettyPrintVersionDescription } from "~/components/logic/pretty-print-version-description";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 
 export interface AppVersionEditableFieldsProps {
-  appVersion?: V2controllersAppVersion;
+  appVersion?: V2controllersAppVersion | SerializeFrom<V2controllersAppVersion>;
   repo?: string;
 }
 
@@ -24,6 +25,10 @@ export const AppVersionEditableFields: React.FunctionComponent<
           When this field is displayed, links will get automatically generated:
         </p>
         <ul className="list-disc pl-5 mb-2">
+          <li>
+            Simple Markdown links will work, like
+            "[example](https://example.com)"
+          </li>
           <li>Text like "[ABC-123]" will become Jira links</li>
           {repo ? (
             <li>Text like "(#123)" will become GitHub links to {repo}</li>
@@ -44,7 +49,7 @@ export const AppVersionEditableFields: React.FunctionComponent<
       </label>
       <p className="w-full break-all">
         Preview:{" "}
-        <PrettyPrintVersionDescription description={description} repo={repo} />
+        <PrettyPrintDescription description={description} repo={repo} />
       </p>
     </div>
   );

--- a/app/components/content/chart-release/chart-release-details.tsx
+++ b/app/components/content/chart-release/chart-release-details.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersChartRelease } from "@sherlock-js-client/sherlock";
 import { AppVersionSummary } from "../app-version/app-version-summary";
 import { ChartVersionSummary } from "../chart-version/chart-version-summary";
@@ -5,7 +6,9 @@ import { MutateControls } from "../helpers";
 import { ChartReleaseColors } from "./chart-release-colors";
 
 export interface ChartReleaseDetailsProps {
-  chartRelease: V2controllersChartRelease;
+  chartRelease:
+    | V2controllersChartRelease
+    | SerializeFrom<V2controllersChartRelease>;
   toChangeVersions?: string;
   toEdit?: string;
   toDelete?: string;

--- a/app/components/content/chart-version/chart-version-details.tsx
+++ b/app/components/content/chart-version/chart-version-details.tsx
@@ -1,12 +1,15 @@
 import { V2controllersChartVersion } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
 import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
-import { PrettyPrintVersionDescription } from "~/components/logic/pretty-print-version-description";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import { MutateControls } from "../helpers";
 import { ChartVersionColors } from "./chart-version-colors";
+import { SerializeFrom } from "@remix-run/node";
 
 export interface ChartVersionDetailsProps {
-  chartVersion: V2controllersChartVersion;
+  chartVersion:
+    | V2controllersChartVersion
+    | SerializeFrom<V2controllersChartVersion>;
   toEdit?: string;
 }
 
@@ -17,7 +20,7 @@ export const ChartVersionDetails: React.FunctionComponent<
     <p>
       Description:{" "}
       {chartVersion.description ? (
-        <PrettyPrintVersionDescription
+        <PrettyPrintDescription
           description={chartVersion.description}
           repo={
             chartVersion.chartInfo?.chartRepo

--- a/app/components/content/chart-version/chart-version-editable-fields.tsx
+++ b/app/components/content/chart-version/chart-version-editable-fields.tsx
@@ -1,10 +1,13 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersChartVersion } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { TextAreaField } from "~/components/interactivity/text-area-field";
-import { PrettyPrintVersionDescription } from "~/components/logic/pretty-print-version-description";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 
 export interface ChartVersionEditableFieldsProps {
-  chartVersion?: V2controllersChartVersion;
+  chartVersion?:
+    | V2controllersChartVersion
+    | SerializeFrom<V2controllersChartVersion>;
   repo?: string;
 }
 
@@ -26,6 +29,10 @@ export const ChartVersionEditableFields: React.FunctionComponent<
           When this field is displayed, links will get automatically generated:
         </p>
         <ul className="list-disc pl-5 mb-2">
+          <li>
+            Simple Markdown links will work, like
+            "[example](https://example.com)"
+          </li>
           <li>Text like "[ABC-123]" will become Jira links</li>
           {repo ? (
             <li>Text like "(#123)" will become GitHub links to {repo}</li>
@@ -46,7 +53,7 @@ export const ChartVersionEditableFields: React.FunctionComponent<
       </label>
       <p className="w-full break-all">
         Preview:{" "}
-        <PrettyPrintVersionDescription description={description} repo={repo} />
+        <PrettyPrintDescription description={description} repo={repo} />
       </p>
     </div>
   );

--- a/app/components/content/chart/chart-creatable-fields.tsx
+++ b/app/components/content/chart/chart-creatable-fields.tsx
@@ -1,8 +1,9 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersChart } from "@sherlock-js-client/sherlock";
 import { TextField } from "~/components/interactivity/text-field";
 
 export interface ChartCreatableFieldsProps {
-  chart?: V2controllersChart;
+  chart?: V2controllersChart | SerializeFrom<V2controllersChart>;
 }
 
 export const ChartCreatableFields: React.FunctionComponent<

--- a/app/components/content/chart/chart-details.tsx
+++ b/app/components/content/chart/chart-details.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersChart } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
 import { AppVersionColors } from "../app-version/app-version-colors";
@@ -7,7 +8,7 @@ import { MutateControls } from "../helpers";
 import { ChartColors } from "./chart-colors";
 
 export interface ChartDetailsProps {
-  chart: V2controllersChart;
+  chart: V2controllersChart | SerializeFrom<V2controllersChart>;
   toChartVersions?: string;
   toAppVersions?: string;
   toChartReleases?: string;

--- a/app/components/content/chart/chart-editable-fields.tsx
+++ b/app/components/content/chart/chart-editable-fields.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersChart } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
@@ -5,7 +6,7 @@ import { TextField } from "~/components/interactivity/text-field";
 import { ChartColors } from "./chart-colors";
 
 export interface ChartEditableFieldsProps {
-  chart?: V2controllersChart;
+  chart?: V2controllersChart | SerializeFrom<V2controllersChart>;
 }
 
 export const ChartEditableFields: React.FunctionComponent<

--- a/app/components/content/cluster/cluster-creatable-fields.tsx
+++ b/app/components/content/cluster/cluster-creatable-fields.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersCluster } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
@@ -5,7 +6,7 @@ import { TextField } from "~/components/interactivity/text-field";
 import { ClusterColors } from "./cluster-colors";
 
 export interface ClusterCreatableFieldsProps {
-  cluster?: V2controllersCluster;
+  cluster?: V2controllersCluster | SerializeFrom<V2controllersCluster>;
 }
 
 export const ClusterCreatableFields: React.FunctionComponent<

--- a/app/components/content/cluster/cluster-details.tsx
+++ b/app/components/content/cluster/cluster-details.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersCluster } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
 import { ChartReleaseColors } from "../chart-release/chart-release-colors";
@@ -5,7 +6,7 @@ import { MutateControls, ProdWarning } from "../helpers";
 import { ClusterColors } from "./cluster-colors";
 
 export interface ClusterDetailsProps {
-  cluster: V2controllersCluster;
+  cluster: V2controllersCluster | SerializeFrom<V2controllersCluster>;
   toChartReleases?: string;
   toEdit?: string;
   toDelete?: string;

--- a/app/components/content/cluster/cluster-editable-fields.tsx
+++ b/app/components/content/cluster/cluster-editable-fields.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersCluster } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
@@ -5,7 +6,7 @@ import { TextField } from "~/components/interactivity/text-field";
 import { ClusterColors } from "./cluster-colors";
 
 export interface ClusterEditableFieldsProps {
-  cluster?: V2controllersCluster;
+  cluster?: V2controllersCluster | SerializeFrom<V2controllersCluster>;
 }
 
 export const ClusterEditableFields: React.FunctionComponent<

--- a/app/components/content/environment/environment-creatable-fields.tsx
+++ b/app/components/content/environment/environment-creatable-fields.tsx
@@ -1,3 +1,4 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersEnvironment } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
@@ -5,7 +6,9 @@ import { TextField } from "~/components/interactivity/text-field";
 import { EnvironmentColors } from "./environment-colors";
 
 export interface EnvironmentCreatableFieldsProps {
-  environment?: V2controllersEnvironment;
+  environment?:
+    | V2controllersEnvironment
+    | SerializeFrom<V2controllersEnvironment>;
   lifecycle: string;
   setLifecycle: (value: string) => void;
   templateEnvironment: string;

--- a/app/components/content/environment/environment-details.tsx
+++ b/app/components/content/environment/environment-details.tsx
@@ -1,12 +1,16 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersEnvironment } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import { ChartReleaseColors } from "../chart-release/chart-release-colors";
 import { ClusterColors } from "../cluster/cluster-colors";
 import { MutateControls, ProdWarning } from "../helpers";
 import { EnvironmentColors } from "./environment-colors";
 
 export interface EnvironmentDetailsProps {
-  environment: V2controllersEnvironment;
+  environment:
+    | V2controllersEnvironment
+    | SerializeFrom<V2controllersEnvironment>;
   toChartReleases?: string;
   toChangeVersions?: string;
   toEdit?: string;
@@ -45,6 +49,11 @@ export const EnvironmentDetails: React.FunctionComponent<
           </NavButton>
         )}
       </div>
+    )}
+    {environment.description && (
+      <h3 className="text-2xl text-color-header-text">
+        <PrettyPrintDescription description={environment.description} />
+      </h3>
     )}
     {environment.lifecycle !== "template" && environment.defaultNamespace && (
       <div className="flex flex-col space-y-4">

--- a/app/components/content/environment/environment-editable-fields.tsx
+++ b/app/components/content/environment/environment-editable-fields.tsx
@@ -1,11 +1,16 @@
+import { SerializeFrom } from "@remix-run/node";
 import { V2controllersEnvironment } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
+import { TextAreaField } from "~/components/interactivity/text-area-field";
 import { TextField } from "~/components/interactivity/text-field";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import { EnvironmentColors } from "./environment-colors";
 
 export interface EnvironmentEditableFieldsProps {
-  environment?: V2controllersEnvironment;
+  environment?:
+    | V2controllersEnvironment
+    | SerializeFrom<V2controllersEnvironment>;
   // When we're creating an environment, we don't want to try to replicate Sherlock's
   // advanced template-default behavior, so this flag tells us to let the user pass
   // empty values for fields where we might otherwise block it.
@@ -43,6 +48,9 @@ export const EnvironmentEditableFields: React.FunctionComponent<
     environment?.namePrefixesDomain != null
       ? environment.namePrefixesDomain.toString()
       : "true"
+  );
+  const [description, setDescription] = useState(
+    environment?.description || ""
   );
   const [preventDeletion, setPreventDeletion] = useState(
     environment?.preventDeletion != null
@@ -158,6 +166,37 @@ export const EnvironmentEditableFields: React.FunctionComponent<
           defaultValue={environment?.defaultFirecloudDevelopRef}
         />
       </label>
+      <label>
+        <h2 className="font-light text-2xl">Description</h2>
+        <p className="mb-2">
+          An extra optional note to include for this environment, just for
+          display in Beehive.
+        </p>
+        <p className="mb-2">
+          When this field is displayed, links will get automatically generated:
+        </p>
+        <ul className="list-disc pl-5 mb-2">
+          <li>
+            Simple Markdown links will work, like
+            "[example](https://example.com)"
+          </li>
+          <li>Text like "[ABC-123]" will become Jira links</li>
+        </ul>
+        <TextAreaField
+          name="description"
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+          placeholder="(can be left empty)"
+          wrap="hard"
+        />
+      </label>
+      {description && (
+        <div className="pl-6 border-l-2 border-color-divider-line mt-4 flex flex-col space-y-4">
+          <p className="w-full break-all">
+            Preview: <PrettyPrintDescription description={description} />
+          </p>
+        </div>
+      )}
       {(creating ? templateInUse : environment?.lifecycle === "dynamic") && (
         <div>
           <h2 className="font-light text-2xl">Prevent Deletion?</h2>

--- a/app/components/interactivity/enum-select.tsx
+++ b/app/components/interactivity/enum-select.tsx
@@ -30,7 +30,7 @@ export const EnumSelect = <T extends any>({
 }: EnumSelectProps<T>) => (
   <div className={`min-h-[3rem] w-full gap-2 ${className}`}>
     {enums.map(([displayValue, valueToSet], index) => (
-      <div className="relative">
+      <div className="relative" key={index}>
         <button
           type="button"
           className={`p-2 w-full h-full shadow-md hover:shadow-lg flex flex-col items-center justify-center ${
@@ -47,7 +47,6 @@ export const EnumSelect = <T extends any>({
               ? "bg-color-nearest-bg before:border-4 font-medium"
               : "bg-color-nearest-bg/50 before:border-2 before:hover:border-4"
           } motion-safe:transition-all before:motion-safe:transition-all`}
-          key={index}
           onClickCapture={(e) => {
             setFieldValue(valueToSet);
             e.preventDefault();

--- a/app/components/logic/pretty-print-description.tsx
+++ b/app/components/logic/pretty-print-description.tsx
@@ -1,20 +1,22 @@
 import React from "react";
 
-export interface PrettyPrintVersionDescriptionProps {
+export interface PrettyPrintDescriptionProps {
   description: string;
   repo?: string;
   jira?: string;
 }
 
-export const PrettyPrintVersionDescription: React.FunctionComponent<
-  PrettyPrintVersionDescriptionProps
+export const PrettyPrintDescription: React.FunctionComponent<
+  PrettyPrintDescriptionProps
 > = ({ description, repo, jira = "broadworkbench" }) => (
   <span>
     {description
-      .split(/((?:\[?[A-Z]+-[0-9]+\]?)|(?:\(?#[0-9]+\)?))/g)
+      .split(
+        /((?:\[?[A-Z]+-[0-9]+\]?)|(?:\(?#[0-9]+\)?)|(?:\[[^\]]+\]\(https?:\/\/[\w\d./?=#]+\)))/g
+      )
       .map((string): React.ReactNode => {
         const ticketMatch = /([A-Z]+-[0-9]+)/.exec(string);
-        if (ticketMatch) {
+        if (jira && ticketMatch) {
           return (
             <a
               href={`https://${jira}.atlassian.net/browse/${ticketMatch[1]}`}
@@ -27,7 +29,7 @@ export const PrettyPrintVersionDescription: React.FunctionComponent<
           );
         }
         const prMatch = /#([0-9]+)/.exec(string);
-        if (prMatch) {
+        if (repo && prMatch) {
           return (
             <a
               href={`https://github.com/${repo}/pull/${prMatch[1]}`}
@@ -36,6 +38,21 @@ export const PrettyPrintVersionDescription: React.FunctionComponent<
               className="underline decoration-color-link-underline"
             >
               {string}
+            </a>
+          );
+        }
+        const linkMatch = /\[([^\]]+)\]\((https?:\/\/[\w\d./?=#]+)\)/.exec(
+          string
+        );
+        if (linkMatch && linkMatch.length >= 2) {
+          return (
+            <a
+              href={linkMatch[2]}
+              target="_blank"
+              rel="noreferrer"
+              className="underline decoration-color-link-underline"
+            >
+              {linkMatch[1]}
             </a>
           );
         }

--- a/app/components/logic/pretty-print-time.tsx
+++ b/app/components/logic/pretty-print-time.tsx
@@ -2,20 +2,25 @@ import { useEffect, useState } from "react";
 
 export interface PrettyPrintTimeProps {
   className?: string;
-  time?: string;
+  time?: string | Date;
 }
 
 export const PrettyPrintTime: React.FunctionComponent<PrettyPrintTimeProps> = ({
   className,
   time,
 }) => {
-  const [timeString, setTimeString] = useState(time || "None");
+  const [timeString, setTimeString] = useState(
+    time ? new Date(time).toISOString() : "None"
+  );
   useEffect(
     () => setTimeString(time ? new Date(time).toLocaleString() : "None"),
     [time]
   );
   return (
-    <span title={time} className={className}>
+    <span
+      title={time ? new Date(time).toISOString() : undefined}
+      className={className}
+    >
       {timeString}
     </span>
   );

--- a/app/routes/__layout/environments.tsx
+++ b/app/routes/__layout/environments.tsx
@@ -70,7 +70,7 @@ const EnvironmentsRoute: React.FunctionComponent = () => {
           >
             {(environment, index) => (
               <NavButton
-                to={`./${environment.name}`}
+                to={`./${environment.name}/chart-releases`}
                 key={index.toString()}
                 {...EnvironmentColors}
               >

--- a/app/routes/__layout/review-changesets.tsx
+++ b/app/routes/__layout/review-changesets.tsx
@@ -36,7 +36,7 @@ import {
   Notification,
 } from "~/components/logic/notification";
 import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
-import { PrettyPrintVersionDescription } from "~/components/logic/pretty-print-version-description";
+import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import { BigActionBox } from "~/components/panel-structures/big-action-box";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { Branch } from "~/components/route-tree/branch";
@@ -648,7 +648,7 @@ const ReviewChangesetsRoute: React.FunctionComponent = () => {
                                         <>
                                           {": "}
                                           {appVersion.description ? (
-                                            <PrettyPrintVersionDescription
+                                            <PrettyPrintDescription
                                               description={
                                                 appVersion.description
                                               }
@@ -839,7 +839,7 @@ const ReviewChangesetsRoute: React.FunctionComponent = () => {
                                   {chartVersion.description && (
                                     <>
                                       {": "}
-                                      <PrettyPrintVersionDescription
+                                      <PrettyPrintDescription
                                         description={chartVersion.description}
                                         repo={
                                           changeset.chartReleaseInfo?.chartInfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@remix-run/node": "^1.8.2",
         "@remix-run/react": "^1.8.2",
         "@remix-run/serve": "^1.8.2",
-        "@sherlock-js-client/sherlock": "^0.0.97",
+        "@sherlock-js-client/sherlock": "^0.0.109",
         "lucide-react": "^0.104.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -27,7 +27,7 @@
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",
         "npm-run-all": "^4.1.5",
-        "postcss": "^8.4.19",
+        "postcss": "^8.4.20",
         "postcss-cli": "^10.1.0",
         "postcss-fail-on-warn": "^0.2.1",
         "postcss-import": "^15.1.0",
@@ -2957,9 +2957,9 @@
       "dev": true
     },
     "node_modules/@sherlock-js-client/sherlock": {
-      "version": "0.0.97",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.0.97.tgz",
-      "integrity": "sha512-R6HHoiNHDKeJAg6u5/ET9PyqjYuBmaIMntZkDobjqzgKD8zSgrbTOnbrs6arUUzy/Fy5MAJzkHXV4L9zW0M6AA=="
+      "version": "0.0.109",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.0.109.tgz",
+      "integrity": "sha512-KgPOHXK5jBH5zyS5XCUg6+axkL1Yf7POg4s27eaHg3jSoz/4C2DR3TfraPZtIYhRu7aIT09Gv6irPU3P97T8IQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -11944,9 +11944,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "funding": [
         {
@@ -17902,9 +17902,9 @@
       "dev": true
     },
     "@sherlock-js-client/sherlock": {
-      "version": "0.0.97",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.0.97.tgz",
-      "integrity": "sha512-R6HHoiNHDKeJAg6u5/ET9PyqjYuBmaIMntZkDobjqzgKD8zSgrbTOnbrs6arUUzy/Fy5MAJzkHXV4L9zW0M6AA=="
+      "version": "0.0.109",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.0.109.tgz",
+      "integrity": "sha512-KgPOHXK5jBH5zyS5XCUg6+axkL1Yf7POg4s27eaHg3jSoz/4C2DR3TfraPZtIYhRu7aIT09Gv6irPU3P97T8IQ=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -24398,9 +24398,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@remix-run/node": "^1.8.2",
     "@remix-run/react": "^1.8.2",
     "@remix-run/serve": "^1.8.2",
-    "@sherlock-js-client/sherlock": "^0.0.97",
+    "@sherlock-js-client/sherlock": "^0.0.109",
     "lucide-react": "^0.104.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -39,7 +39,7 @@
     "husky": "^8.0.2",
     "lint-staged": "^13.1.0",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.19",
+    "postcss": "^8.4.20",
     "postcss-cli": "^10.1.0",
     "postcss-fail-on-warn": "^0.2.1",
     "postcss-import": "^15.1.0",


### PR DESCRIPTION
- Allow simple markdown links in all descriptions
- Note this for app/chart version descriptions
- Fix some type issues arising from Remix being a step more precise in how it types loaders and actions
  - Make the date printing work for both strings and actual date objects
- Add the description field to environment's edit field set
- Make the description appear on environments when it is set
- Make the environment list links automatically open the chart list to guide people towards that view 
  - It's a heavier-weight request but it should load in parallel because of Remix

Requires https://github.com/broadinstitute/sherlock/pull/110 to be deployed

![Screen Shot 2022-12-15 at 12 18 31 PM](https://user-images.githubusercontent.com/29168264/207927172-e608d7b0-d9d9-4715-b669-ac8620dd2e5a.png)
