### PR TITLE
[DDO-2568] Link to Grafana from Beehive

### DIFF
--- a/app/components/boundaries/error-boundary.tsx
+++ b/app/components/boundaries/error-boundary.tsx
@@ -1,7 +1,7 @@
 export function errorBoundary({ error }: { error: Error }) {
   console.log(error);
   return (
-    <div className="bg-color-error-bg border-color-error-border border-2 rounded-lg p-1 border-dashed grow max-w-[33vw]">
+    <div className="bg-color-error-bg border-color-error-border text-color-body-text border-2 rounded-lg p-1 border-dashed grow max-w-[33vw]">
       <p className="font-semibold">Beehive UI Error: {error.message}</p>
       <button
         onClick={() => window.location.reload()}

--- a/app/components/content/chart/chart-details.tsx
+++ b/app/components/content/chart/chart-details.tsx
@@ -106,6 +106,15 @@ export const ChartDetails: React.FunctionComponent<ChartDetailsProps> = ({
         <h2>View Instances of This Chart</h2>
       </NavButton>
     )}
+    {chart.appImageGitRepo && (
+      <a
+        href={`https://grafana.dsp-devops.broadinstitute.org/d/oyhJF6t4k/v2-accelerate-metrics-per-app?&var-chart=${chart.name}`}
+        target="_blank"
+        className="underline decoration-color-link-underline w-fit"
+      >
+        View Accelerate Metrics in Grafana ↗
+      </a>
+    )}
     {(toEdit || toDelete) && (
       <MutateControls
         name={chart.name || ""}

--- a/app/components/content/environment/environment-details.tsx
+++ b/app/components/content/environment/environment-details.tsx
@@ -78,6 +78,15 @@ export const EnvironmentDetails: React.FunctionComponent<
               View in Google Cloud Platform ↗
             </a>
           )}
+        {environment.lifecycle === "static" && (
+          <a
+            href={`https://grafana.dsp-devops.broadinstitute.org/d/Uh_BPk2Vz/v2-accelerate-metrics-per-environment?var-environment=${environment.name}`}
+            target="_blank"
+            className="underline decoration-color-link-underline w-fit"
+          >
+            View Accelerate Metrics in Grafana ↗
+          </a>
+        )}
       </div>
     )}
     {(toEdit || toDelete || toChangeVersions) && (


### PR DESCRIPTION
Charts that have apps and static environments now get links to their respective accelerate metrics pages in Grafana.

Also fixes an incorrect text color inside the error boundary that I noticed while debugging #63