### PR TITLE
[DDO-2575] Add ArgoCD statuses

### DIFF
--- a/app/components/content/chart-release/chart-release-details.tsx
+++ b/app/components/content/chart-release/chart-release-details.tsx
@@ -10,6 +10,7 @@ import {
 import { EnvironmentLinkChip } from "../environment/environment-link-chip";
 import { MutateControls } from "../helpers";
 import { ChartReleaseColors } from "./chart-release-colors";
+import { ArgoLinkChip } from "./chart-release-link-chip";
 
 export interface ChartReleaseDetailsProps {
   chartRelease:
@@ -47,6 +48,11 @@ export const ChartReleaseDetails: React.FunctionComponent<
           )}
         </>
       )}
+      {chartRelease.name &&
+        chartRelease.environmentInfo &&
+        chartRelease.environmentInfo.lifecycle !== "template" && (
+          <ArgoLinkChip chartReleaseName={chartRelease.name} />
+        )}
     </div>
     {chartRelease.appVersionResolver &&
       chartRelease.appVersionResolver != "none" && (

--- a/app/components/content/chart-release/chart-release-link-chip.tsx
+++ b/app/components/content/chart-release/chart-release-link-chip.tsx
@@ -1,0 +1,13 @@
+export const ArgoLinkChip: React.FunctionComponent<{
+  chartReleaseName: string;
+}> = ({ chartReleaseName }) => (
+  <a
+    href={`https://ap-argocd.dsp-devops.broadinstitute.org/applications/ap-argocd/${chartReleaseName}`}
+    target="_blank"
+  >
+    <img
+      src={`https://ap-argocd.dsp-devops.broadinstitute.org/api/badge?name=${chartReleaseName}`}
+      className="h-8 rounded-xl hover:shadow-md motion-safe:transition-all"
+    />
+  </a>
+);

--- a/app/csp.server.ts
+++ b/app/csp.server.ts
@@ -20,7 +20,7 @@ export function getContentSecurityPolicy(nonce?: string | undefined): string {
     "default-src 'self'; " +
     `script-src ${scriptSrc}; ` +
     "style-src 'self' 'report-sample'; " +
-    "img-src 'self' data:; " +
+    "img-src 'self' https://ap-argocd.dsp-devops.broadinstitute.org data:; " +
     "font-src 'self'; " +
     `connect-src ${connectSrc}; ` +
     "media-src 'self'; " +

--- a/app/routes/__layout/index.tsx
+++ b/app/routes/__layout/index.tsx
@@ -37,8 +37,7 @@ const IndexRoute: React.FunctionComponent = () => (
         Welcome to Beehive
       </h1>
       <span className="text-lg">
-        <b className="font-semibold">New!</b> Browse version histories in
-        Beehive
+        <b className="font-semibold">New!</b> View ArgoCD statuses in Beehive
       </span>
     </div>
     <div className="flex flex-wrap justify-center w-full max-w-7xl m-auto min-h-0 items-center">


### PR DESCRIPTION
![Screen Shot 2023-01-10 at 10 26 48 PM](https://user-images.githubusercontent.com/29168264/211710958-4a2ad654-08ba-439f-a7dd-3b37e2aafbfc.png)

Can't style them at all but who cares, it's neat. I made them link back to the chart release in ArgoCD. Had to tweak the CSP but that's what it's there for, was nice to see it do its job.