### PR TITLE
[DDO-2621] Pass CSP nonce to renderToPipeableStream

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -16,15 +16,16 @@ export default function handleRequest(
   return new Promise((resolve, reject) => {
     let didError = false;
 
+    const nonce: string | undefined =
+      remixContext.staticHandlerContext.loaderData["root"]?.cspScriptNonce;
+
     let { pipe, abort } = renderToPipeableStream(
       <RemixServer context={remixContext} url={request.url} />,
       {
+        nonce: nonce,
         onShellReady: () => {
           let body = new PassThrough();
 
-          const nonce: string | undefined =
-            remixContext.staticHandlerContext.loaderData["root"]
-              ?.cspScriptNonce;
           responseHeaders.set(
             "Content-Security-Policy",
             getContentSecurityPolicy(nonce)


### PR DESCRIPTION
[renderToPipeableStream](https://beta.reactjs.org/reference/react-dom/server/renderToPipeableStream) is what Remix uses to server-side render React and then send it to the browser upon initial page load.

The way it handles `<Suspense>` is to inject inline script tags to wire up the websocket. That works great, except for us, because the Content Security Policy shoots down those `unsafe-inline` scripts. Turns out that renderToPipeableStream accepts a nonce though, which is pretty sweet.

I was actually already mucking around in the renderToPipeableStream call because that's how I set the CSP header in the first place. I think I can just move the Remix context read outside of the onShellReady callback and it should still work... and then I have the nonce to inject into renderToPipeableStream.

Honestly, props to Remix for literally exposing the entire guts of the server entrypoint because otherwise I'd be hosed.