### PR TITLE
[DDO-2625] Fix `/r` -> README.md redirect

### DIFF
--- a/app/routes/r._index.ts
+++ b/app/routes/r._index.ts
@@ -4,5 +4,5 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 // laying around in the /routes diectory to actual routes, so
 // this actually does work.
 export function loader(_: LoaderArgs) {
-  return redirect("r/README");
+  return redirect("/r/README");
 }


### PR DESCRIPTION
[https://beehive.dsp-devops.broadinstitute.org/r](https://beehive.dsp-devops.broadinstitute.org/r) <- you'll see what I'm talking about, it needs to go to https://beehive.dsp-devops.broadinstitute.org/r/README