### PR TITLE
[DDO-2628] Fix chart version picker flags

### DIFF
--- a/app/features/sherlock/app-versions/set/app-version-picker.tsx
+++ b/app/features/sherlock/app-versions/set/app-version-picker.tsx
@@ -16,7 +16,7 @@ export const AppVersionPicker: React.FunctionComponent<
   {
     appVersions: SerializeFrom<V2controllersAppVersion[]>;
     chartReleases: SerializeFrom<V2controllersChartRelease[]>;
-    isTargetingChangeset?: boolean;
+    isTargetingChangeset: boolean;
     showFirecloudDevelopRef?: boolean;
 
     initialAppVersionResolver: string;

--- a/app/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel.tsx
+++ b/app/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel.tsx
@@ -169,6 +169,7 @@ export const ChangeChartReleaseVersionsPanel: React.FunctionComponent<{
                 setSidebarFilterText={setSidebarFilterText}
                 chartVersions={chartVersions}
                 chartReleases={otherChartReleases}
+                isTargetingChangeset={true}
                 initialChartVersionResolver={
                   formState?.toChartVersionResolver ||
                   (preconfiguredChartVersionExact && "exact") ||

--- a/app/features/sherlock/chart-versions/set/chart-version-picker.tsx
+++ b/app/features/sherlock/chart-versions/set/chart-version-picker.tsx
@@ -15,7 +15,7 @@ export const ChartVersionPicker: React.FunctionComponent<
   {
     chartVersions: SerializeFrom<V2controllersChartVersion[]>;
     chartReleases: SerializeFrom<V2controllersChartRelease[]>;
-    isTargetingChangeset?: boolean;
+    isTargetingChangeset: boolean;
 
     initialChartVersionResolver: string;
     initialChartVersionExact: string;


### PR DESCRIPTION
This being omitted makes manual chart version selection write the wrong field names into the request body. Added the flag and fixed the type system to prevent this in the future. I messed up during the refactoring and didn't adjust the type system properly so this issue got through :/