### PR TITLE
[DDO-2640] Make the popover loading icon react properly to the non-navigation fetch

### DIFF
--- a/app/features/sherlock/environments/view/environment-offline-icon.tsx
+++ b/app/features/sherlock/environments/view/environment-offline-icon.tsx
@@ -12,7 +12,7 @@ import {
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import { useFetcher, useNavigation } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 import { Power, PowerOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ActionButton } from "~/components/interactivity/action-button";
@@ -63,7 +63,6 @@ export const EnvironmentOfflineIcon: React.FunctionComponent<{
   ]);
 
   const fetcher = useFetcher();
-  const transition = useNavigation();
   useEffect(() => {
     if (fetcher.type === "done") {
       setIsOpen(false);
@@ -141,7 +140,7 @@ export const EnvironmentOfflineIcon: React.FunctionComponent<{
                 <ActionButton
                   sizeClassName="w-full"
                   type="submit"
-                  isLoading={transition.state === "submitting"}
+                  isLoading={fetcher.state !== "idle"}
                   {...EnvironmentColors}
                 >
                   {`${offline ? "Start" : "Stop"} ${environmentName}`}


### PR DESCRIPTION
So this little popup is the first time in Beehive that I'm using `useFetcher`, which allows non-navigation communication with the Remix backend (ever notice that form submissions everywhere else always cause a redirect?)

It works great, only thing I missed was that I accidentally inferred loading state from the navigation context instead of from the special fetcher that's doing this request. This just means that the little Beehive loading icon doesn't appear as you'd expect. It's only really apparent in prod/dev because of all the additional latency from the proxies--locally the button appears to work pretty much instantly.