### PR TITLE
[DDO-2663] Simplify top bar behavior on mobile

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -13,30 +13,16 @@ export const Header: FunctionComponent = () => {
           Beehive
         </span>
       </NavLink>
-      <div className="hidden lg:flex items-center gap-2 overflow-x-auto pr-2">
+      <div className="flex items-center gap-2 overflow-x-auto pr-2">
         {breadcrumbs.map((match, index) => (
           <div
             key={index.toString()}
-            className="shrink-0 flex items-center gap-2 font-light text-xl"
+            className="shrink-0 items-center gap-2 font-light text-xl lg:flex last:flex hidden"
           >
             <span>❯</span>
             {match.handle?.breadcrumb(params)}
           </div>
         ))}
-      </div>
-      <div className="flex lg:hidden items-center gap-2 pr-2 font-light text-xl">
-        {(breadcrumbs.length > 0 && (
-          <>
-            <span>❮</span>
-            {breadcrumbs[breadcrumbs.length - 2]?.handle?.breadcrumb(
-              params
-            ) || <NavLink to="/">Home</NavLink>}
-          </>
-        )) || (
-          <NavLink to="/" className="font-medium text-3xl">
-            Beehive
-          </NavLink>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
I was doing this weird thing of showing the _previous_ page on mobile, because that made sense when mobile horizontal scrolling was wonky, but now that I got scroll snapping working it's fine and I think simpler is better.

In the future I'm going to want the search bar to be here (showing the title of the page in the top bar there is kinda useless) but what it means right now is I just want to make it simpler and leave it.

The behavior now is to show the last breadcrumb, rather than the second to last with a reversed arrow.