### PR TITLE
Disallow capital letters in environment names

### DIFF
--- a/app/features/sherlock/environments/new/environment-creatable-fields.tsx
+++ b/app/features/sherlock/environments/new/environment-creatable-fields.tsx
@@ -163,6 +163,7 @@ export const EnvironmentCreatableFields: React.FunctionComponent<
             }
             required={lifecycle !== "dynamic"}
             value={name}
+            pattern="[^A-Z]*"
             onChange={(e) => setName(e.currentTarget.value)}
           />
         </label>

--- a/app/features/sherlock/environments/new/environment-creatable-fields.tsx
+++ b/app/features/sherlock/environments/new/environment-creatable-fields.tsx
@@ -163,7 +163,7 @@ export const EnvironmentCreatableFields: React.FunctionComponent<
             }
             required={lifecycle !== "dynamic"}
             value={name}
-            pattern="[^A-Z]*"
+            pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"
             onChange={(e) => setName(e.currentTarget.value)}
           />
         </label>


### PR DESCRIPTION
I'm going to add this to Sherlock but Beehive is faster for both me and the end-user (their browser will client-side validate)