### PR TITLE
[DDO-2669] Fully enable scheduling in Beehive #minor

### DIFF
--- a/app/components/interactivity/time-field.tsx
+++ b/app/components/interactivity/time-field.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ClientOnly } from "remix-utils";
-import { zonedISOString } from "~/helpers/date";
+import { localZonedISOString } from "~/helpers/date";
 import { LoadingField } from "./loading-field";
 
 // This component accepts a date/string for an existing value and/or an initial 24-hr wall clock time,
@@ -49,7 +49,7 @@ const InternalTimeField: React.FunctionComponent<
       <input
         type="hidden"
         name={name}
-        value={date ? zonedISOString(date) : ""}
+        value={date ? localZonedISOString(date) : ""}
       />
     </>
   );

--- a/app/components/interactivity/time-field.tsx
+++ b/app/components/interactivity/time-field.tsx
@@ -40,7 +40,11 @@ const InternalTimeField: React.FunctionComponent<
       <input
         type="time"
         pattern={inputTimeRegex.source} // unused by type="time" but if that's unsupported, the fallback is type="text" and this is better than nothing for the user
-        onFocus={(e) => e.currentTarget.showPicker()} // #useThePlatform (it's funny because I didn't know this existed for four hours)
+        onFocus={(e) => {
+          try {
+            e.currentTarget.showPicker();
+          } catch (_) {}
+        }} // #useThePlatform (it's funny because I didn't know this existed for four hours)
         required={required}
         className="w-full pl-4 pr-2 mt-2 shadow-md rounded-2xl h-12 border border-color-text-box-border focus-visible:outline focus-visible:outline-color-focused-element focus-visible:invalid:outline-color-error-border bg-color-nearest-bg placeholder:text-color-placeholder-text invalid:border-dashed invalid:border-color-error-border"
         value={date ? dateToInputTime(date) : ""}

--- a/app/features/sherlock/sherlock.server.ts
+++ b/app/features/sherlock/sherlock.server.ts
@@ -7,6 +7,7 @@ export const SherlockConfiguration = new Configuration({
     {
       pre: async (context) => {
         if (context.init.body) {
+          console.log(JSON.stringify(context.init.body));
           context.init.headers = {
             ...context.init.headers,
             "Content-Type": "application/json",

--- a/app/features/sherlock/sherlock.server.ts
+++ b/app/features/sherlock/sherlock.server.ts
@@ -7,7 +7,6 @@ export const SherlockConfiguration = new Configuration({
     {
       pre: async (context) => {
         if (context.init.body) {
-          console.log(JSON.stringify(context.init.body));
           context.init.headers = {
             ...context.init.headers,
             "Content-Type": "application/json",

--- a/app/helpers/date.ts
+++ b/app/helpers/date.ts
@@ -2,32 +2,29 @@ function pad(num: Number) {
   return (num < 10 ? "0" : "") + num;
 }
 
-const toZonedISOString = function (this: Date) {
-  const tzo = -this.getTimezoneOffset();
+export function localZonedISOString(date: Date) {
+  const tzo = -date.getTimezoneOffset();
   return (
-    this.getFullYear() +
+    date.getFullYear() +
     "-" +
-    pad(this.getMonth() + 1) +
+    pad(date.getMonth() + 1) +
     "-" +
-    pad(this.getDate()) +
+    pad(date.getDate()) +
     "T" +
-    pad(this.getHours()) +
+    pad(date.getHours()) +
     ":" +
-    pad(this.getMinutes()) +
+    pad(date.getMinutes()) +
     ":" +
-    pad(this.getSeconds()) +
+    pad(date.getSeconds()) +
     (tzo >= 0 ? "+" : "-") +
     pad(Math.floor(Math.abs(tzo) / 60)) +
     ":" +
     pad(Math.abs(tzo) % 60)
   );
-};
-
-export function wrapForZonedISOString(date: Date): Date {
-  date.toISOString = toZonedISOString;
-  return date;
 }
 
-export function zonedISOString(date: Date) {
-  return toZonedISOString.call(date);
+export function dateWithCustomISOString(isoString: string): Date {
+  const date = new Date(isoString);
+  date.toISOString = () => isoString; // assign our own function instead lol
+  return date;
 }

--- a/app/routes/_layout.environments.$environmentName.schedule.tsx
+++ b/app/routes/_layout.environments.$environmentName.schedule.tsx
@@ -125,7 +125,8 @@ export default function Route() {
           <EnvironmentScheduleFields
             initialOfflineScheduleBeginEnabled={
               errorInfo?.formState?.offlineScheduleBeginEnabled ||
-              environment.offlineScheduleBeginEnabled
+              environment.offlineScheduleBeginEnabled ||
+              false
             }
             initialOfflineScheduleBeginTime={
               errorInfo?.formState?.offlineScheduleBeginTime ||
@@ -133,7 +134,8 @@ export default function Route() {
             }
             initialOfflineScheduleEndEnabled={
               errorInfo?.formState?.offlineScheduleEndEnabled ||
-              environment.offlineScheduleEndEnabled
+              environment.offlineScheduleEndEnabled ||
+              false
             }
             initialOfflineScheduleEndTime={
               errorInfo?.formState?.offlineScheduleEndTime ||

--- a/app/routes/_layout.environments.$environmentName.schedule.tsx
+++ b/app/routes/_layout.environments.$environmentName.schedule.tsx
@@ -21,7 +21,7 @@ import {
   forwardIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
-import { wrapForZonedISOString } from "~/helpers/date";
+import { dateWithCustomISOString } from "~/helpers/date";
 import { getValidSession } from "~/helpers/get-valid-session.server";
 import { useEnvironmentContext } from "./_layout.environments.$environmentName";
 
@@ -50,13 +50,13 @@ export async function action({ request, params }: ActionArgs) {
       formData.get("offlineScheduleBeginEnabled") === "true",
     offlineScheduleBeginTime:
       offlineScheduleBeginTime && typeof offlineScheduleBeginTime === "string"
-        ? wrapForZonedISOString(new Date(offlineScheduleBeginTime))
+        ? dateWithCustomISOString(offlineScheduleBeginTime)
         : undefined,
     offlineScheduleEndEnabled:
       formData.get("offlineScheduleEndEnabled") === "true",
     offlineScheduleEndTime:
       offlineScheduleEndTime && typeof offlineScheduleEndTime === "string"
-        ? wrapForZonedISOString(new Date(offlineScheduleEndTime))
+        ? dateWithCustomISOString(offlineScheduleEndTime)
         : undefined,
     offlineScheduleEndWeekends:
       typeof offlineScheduleEndWeekends === "string" &&

--- a/app/routes/_layout.environments.$environmentName.tsx
+++ b/app/routes/_layout.environments.$environmentName.tsx
@@ -74,7 +74,7 @@ export default function Route() {
             toChartReleases="./chart-releases"
             toChangeVersions="./change-versions"
             toEdit="./edit"
-            // toSchedule="./schedule"
+            toSchedule="./schedule"
             // toLinkPagerduty={
             //   environment.lifecycle == "static" ? "./link-pagerduty" : ""
             // }

--- a/app/routes/_layout.environments.new.tsx
+++ b/app/routes/_layout.environments.new.tsx
@@ -218,7 +218,7 @@ export default function Route() {
             templateEnvironment={templateEnvironment}
             setTemplateEnvironment={setTemplateEnvironment}
           />
-          {/* {lifecycle === "dynamic" && (
+          {lifecycle === "dynamic" && (
             <>
               <p className="pt-4">
                 By default, BEEs are set to go offline automatically at night to
@@ -250,7 +250,7 @@ export default function Route() {
                 </div>
               </details>
             </>
-          )} */}
+          )}
           <p className="pt-4">
             There's a number of advanced configuration options that can impact
             how the{" "}

--- a/app/routes/_layout.environments.new.tsx
+++ b/app/routes/_layout.environments.new.tsx
@@ -33,7 +33,7 @@ import {
   forwardIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
-import { wrapForZonedISOString } from "~/helpers/date";
+import { dateWithCustomISOString } from "~/helpers/date";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
 import { useSidebar } from "~/hooks/use-sidebar";
 import { commitSession, sessionFields } from "~/session.server";
@@ -89,13 +89,13 @@ export async function action({ request }: ActionArgs) {
       formData.get("offlineScheduleBeginEnabled") === "true",
     offlineScheduleBeginTime:
       offlineScheduleBeginTime && typeof offlineScheduleBeginTime === "string"
-        ? wrapForZonedISOString(new Date(offlineScheduleBeginTime))
+        ? dateWithCustomISOString(offlineScheduleBeginTime)
         : undefined,
     offlineScheduleEndEnabled:
       formData.get("offlineScheduleEndEnabled") === "true",
     offlineScheduleEndTime:
       offlineScheduleEndTime && typeof offlineScheduleEndTime === "string"
-        ? wrapForZonedISOString(new Date(offlineScheduleEndTime))
+        ? dateWithCustomISOString(offlineScheduleEndTime)
         : undefined,
     offlineScheduleEndWeekends:
       typeof offlineScheduleEndWeekends === "string" &&


### PR DESCRIPTION
- For existing environments, default to showing schedule as disabled
- Enable the link from the environment details page to edit the schedule
- Enable the fields during environment creation (**this enables a 7am to 7pm schedule by default for new bees created through beehive**)
- Fix the backend so it uses the iso timestamp it was sent from the frontend