### PR TITLE
[DDO-2705] Allow duplicate notifications

### DIFF
--- a/app/components/logic/notification.tsx
+++ b/app/components/logic/notification.tsx
@@ -112,15 +112,6 @@ export const NotificationComponent: React.FunctionComponent<{
   );
 };
 
-export const NotificationID = (notification: Notification): string => {
-  switch (notification.type) {
-    case "gha":
-      return notification.url;
-    default:
-      return notification.text;
-  }
-};
-
 // This function exists because strongly-typing notifications is actually somewhat unintuitive.
 // TypeScript doesn't have great JSX syntax for "I want to create an object matching this type";
 // the `as` syntax is a type assertion that ignores checking on the object itself. Calling this

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -6,7 +6,6 @@ import { Header } from "~/components/layout/header";
 import {
   Notification,
   NotificationComponent,
-  NotificationID as notificationID,
 } from "~/components/logic/notification";
 import { commitSession, getSession, sessionFields } from "~/session.server";
 
@@ -53,7 +52,7 @@ const LayoutRoute: React.FunctionComponent = () => {
             ...Array.from(
               notificationsToFlash.map(
                 (notification): [string, Notification] => [
-                  notificationID(notification),
+                  new Date().toISOString(),
                   notification,
                 ]
               )


### PR DESCRIPTION
Turns out that the notifications are mostly just good feedback that The Thing Happened, so it makes sense to actually allow duplicates instead of removing them with some sort of ID like I was doing.