### PR TITLE
Fix popover link

### DIFF
--- a/app/features/sherlock/chart-releases/view/app-instance-popover-contents.tsx
+++ b/app/features/sherlock/chart-releases/view/app-instance-popover-contents.tsx
@@ -54,8 +54,8 @@ export const AppInstancePopoverContents: React.FunctionComponent<{
     <ChartReleaseDetails
       chartRelease={chartRelease}
       showChips={false}
-      toChangeVersions={`/environments/${chartRelease.environment}/charts/${chartRelease.chart}/change-versions`}
-      toVersionHistory={`/environments/${chartRelease.environment}/charts/${chartRelease.chart}/version-history`}
+      toChangeVersions={`/environments/${chartRelease.environment}/chart-releases/${chartRelease.chart}/change-versions`}
+      toVersionHistory={`/environments/${chartRelease.environment}/chart-releases/${chartRelease.chart}/version-history`}
     />
   </>
 );


### PR DESCRIPTION
`https://beehive.dsp-devops.broadinstitute.org/environments/dev/charts/firecloudorch/change-versions` should be `https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/firecloudorch/change-versions`