### PR TITLE
[DDO-2797] Fix "select X to include" checkboxes

### DIFF
--- a/app/routes/_layout.environments.$environmentName.change-versions.tsx
+++ b/app/routes/_layout.environments.$environmentName.change-versions.tsx
@@ -97,6 +97,9 @@ export async function action({ request, params }: ActionArgs) {
     includeCharts: formData
       .getAll("includeChart")
       .filter((value): value is string => typeof value === "string"),
+    excludeCharts: formData
+      .getAll("excludeChart")
+      .filter((value): value is string => typeof value === "string"),
     useExactVersionsFromOtherEnvironment:
       typeof useExactVersionsFromOtherEnvironment === "string" &&
       useExactVersionsFromOtherEnvironment.length > 0
@@ -165,10 +168,6 @@ export default function Route() {
       ])
     )
   );
-
-  const includedList = Array.from(includedCharts)
-    .filter(([_, included]) => included)
-    .map(([chart, _]) => chart);
 
   const [sidebar, setSidebar] = useState<ChangeEnvironmentVersionsSidebarModes>(
     "select included charts"
@@ -309,11 +308,11 @@ export default function Route() {
           >
             Select Charts to Include
           </ActionButton>
-          {includedList.map((chartName) => (
+          {Array.from(includedCharts).map(([chartName, included]) => (
             <input
               type="hidden"
               key={chartName}
-              name="includeChart"
+              name={included ? "includeChart" : "excludeChart"}
               value={chartName}
             />
           ))}

--- a/app/routes/_layout.review-changesets.tsx
+++ b/app/routes/_layout.review-changesets.tsx
@@ -267,16 +267,22 @@ export default function Route() {
                               ])
                           );
                         }}
-                        name="changeset"
-                        value={changesetLookup.get(name)?.id}
                         className="align-middle mr-3"
                       />
                       <span className="align-middle">{name}</span>
                     </label>
-                    {changesetLookup.get(name)?.chartReleaseInfo
-                      ?.environmentInfo?.lifecycle === "template" || (
-                      <input type="hidden" name="sync" value={name} />
+                    {included && (
+                      <input
+                        type="hidden"
+                        name="changeset"
+                        value={changesetLookup.get(name)?.id}
+                      />
                     )}
+                    {included &&
+                      changesetLookup.get(name)?.chartReleaseInfo
+                        ?.environmentInfo?.lifecycle !== "template" && (
+                        <input type="hidden" name="sync" value={name} />
+                      )}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
Greg Rushton found two (pretty embarrassing) issues with Beehive stemming from me not getting how my React state and HTML form checkboxes interact (meaning I wasn't sending the right info to Sherlock's API when checkboxes were unchecked).

### Issue 1

"When I deselect charts in the bulk environment update screen, they still seem to be included when I have Sherlock calculate out the changes."

So in Sherlock's API, it used to be that if you passed "includeCharts" in a changeset request, it worked like terraform `--target` (suddenly everything was excluded by default). Beehive would just always set this field, once per each chart to include. That worked great until I built out the "exclude my chart from monolith by default" capability. Suddenly, Beehive wasn't being quite specific enough -- it was setting "includeCharts" but now setting "excludeCharts" was necessary to get Sherlock to ignore its internal defaults of what is/isn't included in monolith.

The fix is in 6543727ebe563f6d2070c29fb96f00bb1da9a8f7. Now, each chart _always_ gets an `<input/>` that swaps back and forth between being "includeChart" or "excludeChart". That gives Beehive's backend enough info to be specific in its request to Sherlock.

I was able to test this by inspecting the HTML itself before and after (in addition to checking the JSON being sent). Some screenshots showing the list state and the HTML of the form:

![Screenshot 2023-04-27 at 11 56 45 AM](https://user-images.githubusercontent.com/29168264/234918782-dcf6e6b2-ef24-4859-9418-443a67d7b1dd.png)

![Screenshot 2023-04-27 at 11 56 20 AM](https://user-images.githubusercontent.com/29168264/234918809-aecf9760-8d9e-4db0-b301-c8f10889b834.png)

You might need to click the above to read the text, sorry it's small.

### Issue 2

"When I deselect a changeset from the review changes screen, it still seems to be applied as if it was included"

The review changesets page does two things -- it applies changesets and then it syncs ArgoCD via GHA. The main oops here was not gating the given chart release's _sync_ based on whether the actual changeset was set to be applied. So even though there was no change in Sherlock, it would result in a spurious sync being sent to ArgoCD -- not a huge problem but not ideal.

The other thing that I realized reading this is that I was kinda really tightly relying on the input checkbox behavior of disappearing from the form when it was unchecked. [According to MDN that should work](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value) but I literally got it mixed up just now in standup, so I'm reducing the reliance on that. Now, both applying the changeset and syncing the chart release are hidden input fields that appear or disappear based on the state of the checkbox.

Whether a changeset is included for applying is based on just whether the checkbox is checked.

Whether a chart release is included for ArgoCD syncing is based on both the checkbox state and making sure that it isn't a template (since there's nothing to sync in that case. That part has been working fine, just calling it out because it features prominently in the diff).

I did the same here -- inspected the HTML to view the generated form structure in addition to checking the backend behavior.

![Screenshot 2023-04-27 at 12 12 06 PM](https://user-images.githubusercontent.com/29168264/234924680-8e79e0d7-0601-4faa-be0f-3c0e2295d6e9.png)

![Screenshot 2023-04-27 at 12 12 22 PM](https://user-images.githubusercontent.com/29168264/234924733-80ebf502-31f5-4779-8e5d-beb1ff9abf17.png)

I think the basic thing here was me not really properly thinking about the HTML form checkboxes not being sent direct to Sherlock -- they get manually parsed to a JSON type inside Remix's backend, so behaviors of Sherlock's API like "if you don't include something it doesn't get included" isn't a paradigm that I can actually cleanly carry into my frontend thinking.