### PR TITLE
[DDO-2798] Fix Changeset checkbox sizing

### DIFF
--- a/app/features/sherlock/changesets/list/changeset-entry.tsx
+++ b/app/features/sherlock/changesets/list/changeset-entry.tsx
@@ -102,7 +102,7 @@ export const ChangesetEntry: React.FunctionComponent<{
           !changeset.appliedAt && (
             <input
               type="checkbox"
-              className="w-9"
+              className="w-9 shrink-0"
               title="Include in the changes to apply?"
               checked={includedCheckboxValue}
               onChange={() => {

--- a/app/features/sherlock/changesets/list/changeset-entry.tsx
+++ b/app/features/sherlock/changesets/list/changeset-entry.tsx
@@ -92,7 +92,7 @@ export const ChangesetEntry: React.FunctionComponent<{
       } flex flex-col gap-2 px-6 py-4 text-color-body-text`}
     >
       <div
-        className="flex flex-row gap-4 font-light cursor-pointer"
+        className="flex flex-row gap-4 items-start font-light cursor-pointer"
         onClick={() => setMinimized(!minimized)}
       >
         {appliable &&
@@ -102,7 +102,7 @@ export const ChangesetEntry: React.FunctionComponent<{
           !changeset.appliedAt && (
             <input
               type="checkbox"
-              className="w-9 shrink-0"
+              className="w-9 h-9 mt-1 shrink-0 cursor-pointer"
               title="Include in the changes to apply?"
               checked={includedCheckboxValue}
               onChange={() => {

--- a/app/routes/_layout.review-changesets.tsx
+++ b/app/routes/_layout.review-changesets.tsx
@@ -269,7 +269,7 @@ export default function Route() {
                         }}
                         name="changeset"
                         value={changesetLookup.get(name)?.id}
-                        className="align-middle mr-3"
+                        className="align-middle mr-3 cursor-pointer"
                       />
                       <span className="align-middle">{name}</span>
                     </label>


### PR DESCRIPTION
Split from #188, some styling fixes for the review changeset page.

Before:
![Screenshot 2023-04-27 at 12 23 04 PM](https://user-images.githubusercontent.com/29168264/234928147-ca36d88c-97c9-4d67-817d-8027ddeb8882.png)

After:
![Screenshot 2023-04-27 at 12 34 00 PM](https://user-images.githubusercontent.com/29168264/234930055-34f1d0ec-5684-4590-954d-17c57fb06f73.png)

It also makes the cursor have the "this is a button" pointer look but I can't screenshot that very well