### PR TITLE
[DDO-2800] Add v2_normalizeFormMethod

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -9,6 +9,7 @@ module.exports = {
     v2_meta: true,
     v2_errorBoundary: true,
     v2_routeConvention: true,
+    v2_normalizeFormMethod: true,
     unstable_postcss: true,
   },
 };


### PR DESCRIPTION
Docs here https://remix.run/docs/en/main/pages/v2#formmethod

Remix accidentally lowercases the HTTP method in some of its APIs, and they're fixing that in v2. Lucky for us, we literally never use `formMethod` in Beehive, so we can enable this flag to surpress the warning for free.

Checked via the usual "run it" and also double-check that no usages snuck in somewhere:

![Screenshot 2023-04-27 at 12 40 20 PM](https://user-images.githubusercontent.com/29168264/234931444-76dcc533-b687-42de-93c4-0bc2480055e0.png)
