### PR TITLE
[DDO-2833] Make Terra UI link open in a new tab

### DIFF
--- a/app/components/interactivity/external-nav-button.tsx
+++ b/app/components/interactivity/external-nav-button.tsx
@@ -1,6 +1,9 @@
-import { NavButtonProps } from "./nav-button";
+import type { ComponentProps } from "react";
+import type { NavButtonProps } from "./nav-button";
 
-export const ExternalNavButton: React.FunctionComponent<NavButtonProps> = ({
+export const ExternalNavButton: React.FunctionComponent<
+  NavButtonProps & Pick<ComponentProps<"a">, "target">
+> = ({
   to,
   beforeBorderClassName,
   textAlignment = "text-left",
@@ -8,6 +11,7 @@ export const ExternalNavButton: React.FunctionComponent<NavButtonProps> = ({
   children,
   disabled,
   prod,
+  target,
 }) => (
   <div
     data-theme-prod={prod}
@@ -22,6 +26,7 @@ export const ExternalNavButton: React.FunctionComponent<NavButtonProps> = ({
           ? "before:border-color-neutral-soft-border"
           : beforeBorderClassName
       } motion-safe:transition-all before:motion-safe:transition-all`}
+      target={target}
     >
       <div
         className={`shrink-0 flex flex-row gap-2 justify-between items-center h-full w-full pl-4 pr-16 py-2 ${

--- a/app/features/sherlock/environments/view/environment-details.tsx
+++ b/app/features/sherlock/environments/view/environment-details.tsx
@@ -98,6 +98,7 @@ export const EnvironmentDetails: React.FunctionComponent<
           icon={<TerraIcon className="h-[1.75rem]" />}
           to={toTerraUI}
           beforeBorderClassName="before:border-[#73ad43]"
+          target="_blank"
         >
           <h2>Visit Terra UI</h2>
         </ExternalNavButton>

--- a/app/features/sherlock/environments/view/environment-details.tsx
+++ b/app/features/sherlock/environments/view/environment-details.tsx
@@ -100,7 +100,7 @@ export const EnvironmentDetails: React.FunctionComponent<
           beforeBorderClassName="before:border-[#73ad43]"
           target="_blank"
         >
-          <h2>Visit Terra UI</h2>
+          <h2>Visit Terra UI ↗</h2>
         </ExternalNavButton>
       )}
     </div>


### PR DESCRIPTION
You can tell I've been seeing clips from Typescript influencers on Twitter because I used `Pick<ComponentProps<"a">, "target">` to copy the builtin target prop's autocomplete.

(Got a request for the button to open in a new tab so 🪄. Adds the little arrow too that I use elsewhere for the new tab links)
![Screenshot 2023-05-08 at 3 56 15 PM](https://user-images.githubusercontent.com/29168264/236921074-73dd5bc1-a773-45b7-8846-18edfee89c82.png)

## Testing

Ran it. The link opens in a new tab. 🤷

## Risk

Realistically zero IMO.