### PR TITLE
[DDO-2843] Respect `IAP_TOKEN` if running against remote Sherlock from localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. You may want to dump a copy of Sherlock's database into your local one to have some data to play with.
 
 > **Note**
+>
 > If you don't want to run a local Sherlock but you have a copy of Thelma, you can run Beehive against Sherlock's dev instance like this:
 >
 > ```bash
@@ -24,6 +25,7 @@ You'll probably want a local instance of Sherlock running -- `make local-up` fro
 > ```
 
 > **Warning**
+>
 > If you want to do the above but against Sherlock's prod instance (careful!):
 >
 > ```bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,21 @@
 
 4. Run `npm install` to download dependencies and `npm run dev` to spin up the development server
 
-You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. If you're set up with Thelma, `thelma state export` will give your local Sherlock instance some familiar-looking data.
+You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. You may want to dump a copy of Sherlock's database into your local one to have some data to play with.
+
+> **Note**
+> If you don't want to run a local Sherlock but you have a copy of Thelma, you can run Beehive against Sherlock's dev instance like this:
+>
+> ```bash
+> IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock-dev.dsp-devops.broadinstitute.org' npm run dev
+> ```
+
+> **Warning**
+> If you want to do the above but against Sherlock's prod instance (careful!):
+>
+> ```bash
+> IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock.dsp-devops.broadinstitute.org' npm run dev
+> ```
 
 ### If you're using Visual Studio Code
 

--- a/app/features/sherlock/sherlock.server.ts
+++ b/app/features/sherlock/sherlock.server.ts
@@ -45,10 +45,18 @@ export const SherlockConfiguration = new Configuration({
 
 const IapJwtHeader = "x-goog-iap-jwt-assertion";
 
-export function forwardIAP(request: Request): RequestInit {
-  return {
-    headers: request.headers.has(IapJwtHeader)
-      ? { [IapJwtHeader]: request.headers.get(IapJwtHeader)! }
-      : undefined,
-  };
+export function handleIAP(request: Request): RequestInit {
+  if (request.headers.has(IapJwtHeader)) {
+    // Request looks like post-IAP, so forward the header
+    return { headers: { [IapJwtHeader]: request.headers.get(IapJwtHeader)! } };
+  }
+  if (
+    process.env.NODE_ENV !== "production" &&
+    process.env.SHERLOCK_BASE_URL?.startsWith("https") &&
+    process.env.IAP_TOKEN
+  ) {
+    // Not in production mode, talking to a real instance, and we were given a token, so use it
+    return { headers: { Authorization: `Bearer ${process.env.IAP_TOKEN}` } };
+  }
+  return {};
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,7 +25,7 @@ import { PagerdutyTokenContext } from "./components/logic/pagerduty-token";
 import { LoadThemeSetter } from "./components/logic/theme";
 import { PanelErrorBoundary } from "./errors/components/error-boundary";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "./features/sherlock/sherlock.server";
 import { generateNonce } from "./helpers/nonce.server";
@@ -136,7 +136,7 @@ export async function loader({ request }: LoaderArgs) {
                     githubAccessToken: data.access_token,
                   },
                 },
-                forwardIAP(request)
+                handleIAP(request)
               )
               .then(
                 (user) =>

--- a/app/routes/_layout.apps.$chartName._index.tsx
+++ b/app/routes/_layout.apps.$chartName._index.tsx
@@ -2,8 +2,8 @@ import { LoaderArgs } from "@remix-run/node";
 import { useLoaderData, useOutletContext } from "@remix-run/react";
 import {
   AppVersionsApi,
-  ChartsApi,
   ChartVersionsApi,
+  ChartsApi,
 } from "@sherlock-js-client/sherlock";
 import { InsetPanel } from "~/components/layout/inset-panel";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
@@ -12,12 +12,12 @@ import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { interleaveVersionPromises } from "~/features/sherlock/interleaved-versions/interleave-version-promises";
 import { InterleavedVersionEntry } from "~/features/sherlock/interleaved-versions/interleaved-version-entry";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
-  const forwardedIAP = forwardIAP(request);
+  const forwardedIAP = handleIAP(request);
 
   return new ChartsApi(SherlockConfiguration)
     .apiV2ChartsSelectorGet(

--- a/app/routes/_layout.apps.$chartName.from-dev.tsx
+++ b/app/routes/_layout.apps.$chartName.from-dev.tsx
@@ -35,7 +35,7 @@ import { EnvironmentColors } from "~/features/sherlock/environments/environment-
 import { interleaveVersionPromises } from "~/features/sherlock/interleaved-versions/interleave-version-promises";
 import { InterleavedVersionEntry } from "~/features/sherlock/interleaved-versions/interleaved-version-entry";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
@@ -43,7 +43,7 @@ import { getValidSession } from "~/helpers/get-valid-session.server";
 import { loader as parentLoader } from "~/routes/_layout.apps.$chartName";
 
 export async function loader({ request, params }: LoaderArgs) {
-  const forwardedIAP = forwardIAP(request);
+  const forwardedIAP = handleIAP(request);
   const chartReleasesApi = new ChartReleasesApi(SherlockConfiguration);
   return promiseHash({
     inDev: chartReleasesApi
@@ -116,7 +116,7 @@ export async function action({ request, params }: ActionArgs) {
             ),
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (changesets) =>

--- a/app/routes/_layout.apps.$chartName.from-staging.tsx
+++ b/app/routes/_layout.apps.$chartName.from-staging.tsx
@@ -28,13 +28,13 @@ import { EnvironmentColors } from "~/features/sherlock/environments/environment-
 import { interleaveVersionPromises } from "~/features/sherlock/interleaved-versions/interleave-version-promises";
 import { InterleavedVersionEntry } from "~/features/sherlock/interleaved-versions/interleaved-version-entry";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
 
 export async function loader({ request, params }: LoaderArgs) {
-  const forwardedIAP = forwardIAP(request);
+  const forwardedIAP = handleIAP(request);
   const chartReleasesApi = new ChartReleasesApi(SherlockConfiguration);
   return promiseHash({
     inStaging: chartReleasesApi
@@ -95,7 +95,7 @@ export async function action({ request, params }: ActionArgs) {
             ),
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (changesets) =>

--- a/app/routes/_layout.apps.$chartName.tsx
+++ b/app/routes/_layout.apps.$chartName.tsx
@@ -25,7 +25,7 @@ import { SonarCloudLinkChip } from "~/features/sherlock/charts/chart-link-chip";
 import { AppPopoverContents } from "~/features/sherlock/charts/view/app-popover-contents";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { panelSizeToInnerClassName } from "~/helpers/panel-size";
@@ -45,7 +45,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 ];
 
 export async function loader({ request, params }: LoaderArgs) {
-  const forwardedIAP = forwardIAP(request);
+  const forwardedIAP = handleIAP(request);
   const chartReleasesApi = new ChartReleasesApi(SherlockConfiguration);
   return json(
     await promiseHash({

--- a/app/routes/_layout.apps.tsx
+++ b/app/routes/_layout.apps.tsx
@@ -18,7 +18,7 @@ import { matchChartRelease } from "~/features/sherlock/chart-releases/list/match
 import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { ListChartButtonText } from "~/features/sherlock/charts/list/list-chart-button-text";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 
@@ -33,7 +33,7 @@ export const meta: V2_MetaFunction = () => [
 ];
 
 export async function loader({ request }: LoaderArgs) {
-  const forwardedIAP = forwardIAP(request);
+  const forwardedIAP = handleIAP(request);
   return json(
     await promiseHash({
       chartReleases: new ChartReleasesApi(SherlockConfiguration)

--- a/app/routes/_layout.charts.$chartName.app-versions.$appVersion.edit.tsx
+++ b/app/routes/_layout.charts.$chartName.app-versions.$appVersion.edit.tsx
@@ -13,7 +13,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { AppVersionColors } from "~/features/sherlock/app-versions/app-version-colors";
 import { AppVersionEditableFields } from "~/features/sherlock/app-versions/edit/app-version-editable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -52,7 +52,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.chartName}/${params.appVersion}`,
         appVersion: appVersionRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (appVersion) =>

--- a/app/routes/_layout.charts.$chartName.app-versions.$appVersion.tsx
+++ b/app/routes/_layout.charts.$chartName.app-versions.$appVersion.tsx
@@ -14,8 +14,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { AppVersionColors } from "~/features/sherlock/app-versions/app-version-colors";
 import { AppVersionDetails } from "~/features/sherlock/app-versions/view/app-version-details";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useChartContext } from "~/routes/_layout.charts.$chartName";
 
@@ -39,7 +39,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new AppVersionsApi(SherlockConfiguration)
     .apiV2AppVersionsSelectorGet(
       { selector: `${params.chartName}/${params.appVersion}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.charts.$chartName.app-versions.tsx
+++ b/app/routes/_layout.charts.$chartName.app-versions.tsx
@@ -19,8 +19,8 @@ import { AppVersionColors } from "~/features/sherlock/app-versions/app-version-c
 import { ListAppVersionButtonText } from "~/features/sherlock/app-versions/list/list-app-version-button-text";
 import { matchAppVersion } from "~/features/sherlock/app-versions/list/match-app-version";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useChartContext } from "~/routes/_layout.charts.$chartName";
 
@@ -40,7 +40,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 
 export async function loader({ request, params }: LoaderArgs) {
   return new AppVersionsApi(SherlockConfiguration)
-    .apiV2AppVersionsGet({ chart: params.chartName || "" }, forwardIAP(request))
+    .apiV2AppVersionsGet({ chart: params.chartName || "" }, handleIAP(request))
     .catch(errorResponseThrower);
 }
 

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.applied-changesets.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.applied-changesets.tsx
@@ -7,8 +7,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { AppliedChangesetsPanel } from "~/features/sherlock/changesets/list/applied-changesets-panel";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useChartChartReleaseContext } from "~/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName";
 
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderArgs) {
           offset: offset,
           limit: limit,
         },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     offset,

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.change-versions.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.change-versions.tsx
@@ -26,7 +26,7 @@ import {
 import { ChangeChartReleaseVersionsPanel } from "~/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel";
 import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/chart-release-sorter";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -55,7 +55,7 @@ export function loader({ request, params }: LoaderArgs) {
   const preconfiguredChartVersionExact = url.searchParams.get("chart");
   return Promise.all([
     new ChartReleasesApi(SherlockConfiguration)
-      .apiV2ChartReleasesGet({ chart: params.chartName }, forwardIAP(request))
+      .apiV2ChartReleasesGet({ chart: params.chartName }, handleIAP(request))
       .then(
         (chartReleases) =>
           Array.from(
@@ -71,13 +71,13 @@ export function loader({ request, params }: LoaderArgs) {
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -101,7 +101,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then((changesets) => {
       return changesets.length > 0

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.database-instance.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.database-instance.tsx
@@ -18,7 +18,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import { DatabaseInstancePanel } from "~/features/sherlock/database-instances/database-instance-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -45,7 +45,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new DatabaseInstancesApi(SherlockConfiguration)
     .apiV2DatabaseInstancesSelectorGet(
       { selector: `chart-release/${params.chartReleaseName}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(() => null);
 }
@@ -64,7 +64,7 @@ export async function action({ request, params }: ActionArgs) {
         databaseInstance: databaseInstanceRequest,
         selector: `chart-release/${params.chartReleaseName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
@@ -6,7 +6,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { runGha } from "~/features/github/run-gha";
 import { ChartReleaseDeletePanel } from "~/features/sherlock/chart-releases/delete/chart-release-delete-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
@@ -37,7 +37,7 @@ export async function action({ request, params }: ActionArgs) {
       {
         selector: `${params.chartReleaseName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.edit.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.edit.tsx
@@ -8,7 +8,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import { ChartReleaseEditPanel } from "~/features/sherlock/chart-releases/edit/chart-release-edit-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -49,7 +49,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.chartReleaseName || "",
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.link-pagerduty.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.link-pagerduty.tsx
@@ -24,7 +24,7 @@ import {
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import { LinkPagerdutyPanel } from "~/features/sherlock/pagerduty-integrations/link-pagerduty/link-pagerduty-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -50,7 +50,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new PagerdutyIntegrationsApi(SherlockConfiguration)
-      .apiV2PagerdutyIntegrationsGet({}, forwardIAP(request))
+      .apiV2PagerdutyIntegrationsGet({}, handleIAP(request))
       .catch(errorResponseThrower),
     getPdAppIdFromEnv(),
   ]);
@@ -70,7 +70,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.chartReleaseName || "",
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.tsx
@@ -17,8 +17,8 @@ import { ChartReleaseDetails } from "~/features/sherlock/chart-releases/view/cha
 import { EnvironmentOfflineIcon } from "~/features/sherlock/environments/offline/environment-offline-icon";
 import { ProdWarning } from "~/features/sherlock/prod-warning";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -43,7 +43,7 @@ export async function loader({ request, params }: LoaderArgs) {
       {
         selector: params.chartReleaseName || "",
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.charts.$chartName.chart-releases.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.tsx
@@ -20,8 +20,8 @@ import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/char
 import { ListChartReleaseButtonText } from "~/features/sherlock/chart-releases/list/list-chart-release-button-text";
 import { matchChartRelease } from "~/features/sherlock/chart-releases/list/match-chart-release";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesGet(
       { chart: params.chartName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartReleases) => chartReleases.sort(chartReleaseSorter),

--- a/app/routes/_layout.charts.$chartName.chart-versions.$chartVersion.edit.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-versions.$chartVersion.edit.tsx
@@ -13,7 +13,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { ChartVersionColors } from "~/features/sherlock/chart-versions/chart-version-colors";
 import { ChartVersionEditableFields } from "~/features/sherlock/chart-versions/edit/chart-version-editable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -52,7 +52,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.chartName}/${params.chartVersion}`,
         chartVersion: chartVersionRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartVersion) =>

--- a/app/routes/_layout.charts.$chartName.chart-versions.$chartVersion.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-versions.$chartVersion.tsx
@@ -14,8 +14,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { ChartVersionColors } from "~/features/sherlock/chart-versions/chart-version-colors";
 import { ChartVersionDetails } from "~/features/sherlock/chart-versions/view/chart-version-details";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useChartContext } from "~/routes/_layout.charts.$chartName";
 
@@ -39,7 +39,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartVersionsApi(SherlockConfiguration)
     .apiV2ChartVersionsSelectorGet(
       { selector: `${params.chartName}/${params.chartVersion}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.charts.$chartName.chart-versions.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-versions.tsx
@@ -19,8 +19,8 @@ import { ChartVersionColors } from "~/features/sherlock/chart-versions/chart-ver
 import { ListChartVersionButtonText } from "~/features/sherlock/chart-versions/list/list-chart-version-button-text";
 import { matchChartVersion } from "~/features/sherlock/chart-versions/list/match-chart-version";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useChartContext } from "~/routes/_layout.charts.$chartName";
 
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartVersionsApi(SherlockConfiguration)
     .apiV2ChartVersionsGet(
       { chart: params.chartName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.charts.$chartName.delete.tsx
+++ b/app/routes/_layout.charts.$chartName.delete.tsx
@@ -11,7 +11,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { ChartDeleteDescription } from "~/features/sherlock/charts/delete/chart-delete-description";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
@@ -33,7 +33,7 @@ export async function action({ request, params }: ActionArgs) {
   return new ChartsApi(SherlockConfiguration)
     .apiV2ChartsSelectorDelete(
       { selector: params.chartName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(() => redirect("/charts"), makeErrorResponseReturner());
 }

--- a/app/routes/_layout.charts.$chartName.edit.tsx
+++ b/app/routes/_layout.charts.$chartName.edit.tsx
@@ -10,7 +10,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { ChartEditableFields } from "~/features/sherlock/charts/edit/chart-editable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -46,7 +46,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.chartName || "",
         chart: chartRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chart) => redirect(`/charts/${chart.name}`),

--- a/app/routes/_layout.charts.$chartName.tsx
+++ b/app/routes/_layout.charts.$chartName.tsx
@@ -14,8 +14,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { ChartDetails } from "~/features/sherlock/charts/view/chart-details";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -32,7 +32,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartsApi(SherlockConfiguration)
     .apiV2ChartsSelectorGet(
       { selector: params.chartName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.charts.new.tsx
+++ b/app/routes/_layout.charts.new.tsx
@@ -12,7 +12,7 @@ import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { ChartEditableFields } from "~/features/sherlock/charts/edit/chart-editable-fields";
 import { ChartCreatableFields } from "~/features/sherlock/charts/new/chart-creatable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -43,7 +43,7 @@ export async function action({ request }: ActionArgs) {
   };
 
   return new ChartsApi(SherlockConfiguration)
-    .apiV2ChartsPost({ chart: chartRequest }, forwardIAP(request))
+    .apiV2ChartsPost({ chart: chartRequest }, handleIAP(request))
     .then(
       (chart) => redirect(`/charts/${chart.name}`),
       makeErrorResponseReturner(chartRequest)

--- a/app/routes/_layout.charts.tsx
+++ b/app/routes/_layout.charts.tsx
@@ -14,8 +14,8 @@ import { chartSorter } from "~/features/sherlock/charts/list/chart-sorter";
 import { ListChartButtonText } from "~/features/sherlock/charts/list/list-chart-button-text";
 import { matchChart } from "~/features/sherlock/charts/list/match-chart";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -30,7 +30,7 @@ export const meta: V2_MetaFunction = () => [
 
 export async function loader({ request }: LoaderArgs) {
   return new ChartsApi(SherlockConfiguration)
-    .apiV2ChartsGet({}, forwardIAP(request))
+    .apiV2ChartsGet({}, handleIAP(request))
     .then((charts) => charts.sort(chartSorter), errorResponseThrower);
 }
 

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.applied-changesets.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.applied-changesets.tsx
@@ -7,8 +7,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { AppliedChangesetsPanel } from "~/features/sherlock/changesets/list/applied-changesets-panel";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useClusterChartReleaseContext } from "~/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName";
 
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderArgs) {
           offset: offset,
           limit: limit,
         },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     offset,

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.change-versions.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.change-versions.tsx
@@ -26,7 +26,7 @@ import {
 import { ChangeChartReleaseVersionsPanel } from "~/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel";
 import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/chart-release-sorter";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -55,7 +55,7 @@ export function loader({ request, params }: LoaderArgs) {
   const preconfiguredChartVersionExact = url.searchParams.get("chart");
   return Promise.all([
     new ChartReleasesApi(SherlockConfiguration)
-      .apiV2ChartReleasesGet({ chart: params.chartName }, forwardIAP(request))
+      .apiV2ChartReleasesGet({ chart: params.chartName }, handleIAP(request))
       .then(
         (chartReleases) =>
           Array.from(
@@ -71,13 +71,13 @@ export function loader({ request, params }: LoaderArgs) {
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -101,7 +101,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then((changesets) => {
       return changesets.length > 0

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.database-instance.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.database-instance.tsx
@@ -18,7 +18,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import { DatabaseInstancePanel } from "~/features/sherlock/database-instances/database-instance-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -47,7 +47,7 @@ export async function loader({ request, params }: LoaderArgs) {
       {
         selector: `chart-release/${params.clusterName}/${params.namespace}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(() => null);
 }
@@ -66,7 +66,7 @@ export async function action({ request, params }: ActionArgs) {
         databaseInstance: databaseInstanceRequest,
         selector: `chart-release/${params.clusterName}/${params.namespace}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.delete.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.delete.tsx
@@ -6,7 +6,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { runGha } from "~/features/github/run-gha";
 import { ChartReleaseDeletePanel } from "~/features/sherlock/chart-releases/delete/chart-release-delete-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
@@ -37,7 +37,7 @@ export async function action({ request, params }: ActionArgs) {
       {
         selector: `${params.clusterName}/${params.namespace}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.edit.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.edit.tsx
@@ -8,7 +8,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import { ChartReleaseEditPanel } from "~/features/sherlock/chart-releases/edit/chart-release-edit-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -49,7 +49,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.clusterName}/${params.namespace}/${params.chartName}`,
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.link-pagerduty.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.link-pagerduty.tsx
@@ -24,7 +24,7 @@ import {
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import { LinkPagerdutyPanel } from "~/features/sherlock/pagerduty-integrations/link-pagerduty/link-pagerduty-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -50,7 +50,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new PagerdutyIntegrationsApi(SherlockConfiguration)
-      .apiV2PagerdutyIntegrationsGet({}, forwardIAP(request))
+      .apiV2PagerdutyIntegrationsGet({}, handleIAP(request))
       .catch(errorResponseThrower),
     getPdAppIdFromEnv(),
   ]);
@@ -70,7 +70,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.environmentName}/${params.chartName}`,
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.tsx
@@ -15,8 +15,8 @@ import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-rel
 import { ChartReleaseDetails } from "~/features/sherlock/chart-releases/view/chart-release-details";
 import { EnvironmentOfflineIcon } from "~/features/sherlock/environments/offline/environment-offline-icon";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -41,7 +41,7 @@ export async function loader({ request, params }: LoaderArgs) {
       {
         selector: `${params.clusterName}/${params.namespace}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
@@ -34,7 +34,7 @@ import { ChartReleaseEditableFields } from "~/features/sherlock/chart-releases/e
 import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/chart-release-sorter";
 import { ChartVersionPicker } from "~/features/sherlock/chart-versions/set/chart-version-picker";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -64,11 +64,11 @@ export async function loader({ request, params }: LoaderArgs) {
     new ChartsApi(SherlockConfiguration)
       .apiV2ChartsSelectorGet(
         { selector: params.chartName || "" },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartReleasesApi(SherlockConfiguration)
-      .apiV2ChartReleasesGet({ chart: params.chartName }, forwardIAP(request))
+      .apiV2ChartReleasesGet({ chart: params.chartName }, handleIAP(request))
       .then(
         (chartReleases) =>
           chartReleases
@@ -83,13 +83,13 @@ export async function loader({ request, params }: LoaderArgs) {
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
   ]);
@@ -112,7 +112,7 @@ export async function action({ request, params }: ActionArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesPost(
       { chartRelease: chartReleaseRequest },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.tsx
@@ -19,8 +19,8 @@ import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import { chartSorter } from "~/features/sherlock/charts/list/chart-sorter";
 import { environmentSorter } from "~/features/sherlock/environments/list/environment-sorter";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useClusterContext } from "~/routes/_layout.clusters.$clusterName";
 
@@ -41,13 +41,13 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new ChartsApi(SherlockConfiguration)
-      .apiV2ChartsGet({}, forwardIAP(request))
+      .apiV2ChartsGet({}, handleIAP(request))
       .then((charts) => charts.sort(chartSorter), errorResponseThrower),
     // We don't actually need the environments here, but loading them here and passing
     // them down through via context means we won't be loading them repeatedly on
     // the next page if the user is browsing charts to deploy by clicking on them.
     new EnvironmentsApi(SherlockConfiguration)
-      .apiV2EnvironmentsGet({}, forwardIAP(request))
+      .apiV2EnvironmentsGet({}, handleIAP(request))
       .then(
         (environments) => environments.sort(environmentSorter),
         errorResponseThrower

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.tsx
@@ -20,8 +20,8 @@ import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/char
 import { ListChartReleaseButtonText } from "~/features/sherlock/chart-releases/list/list-chart-release-button-text";
 import { matchChartRelease } from "~/features/sherlock/chart-releases/list/match-chart-release";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useClusterContext } from "~/routes/_layout.clusters.$clusterName";
 
@@ -54,7 +54,7 @@ export async function loader({ request, params }: LoaderArgs) {
         cluster: params.clusterName || "",
         namespace: params.filterNamespace || undefined,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       // Sherlock's API doesn't really have a great mechanism for

--- a/app/routes/_layout.clusters.$clusterName.edit.tsx
+++ b/app/routes/_layout.clusters.$clusterName.edit.tsx
@@ -14,7 +14,7 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
 import { ClusterEditableFields } from "~/features/sherlock/clusters/edit/cluster-editable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -43,7 +43,7 @@ export async function action({ request, params }: ActionArgs) {
   return new ClustersApi(SherlockConfiguration)
     .apiV2ClustersSelectorPatch(
       { selector: params.clusterName || "", cluster: clusterRequest },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (cluster) => redirect(`/clusters/${cluster.name}`),

--- a/app/routes/_layout.clusters.$clusterName.tsx
+++ b/app/routes/_layout.clusters.$clusterName.tsx
@@ -15,8 +15,8 @@ import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
 import { ClusterDetails } from "~/features/sherlock/clusters/view/cluster-details";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -35,7 +35,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ClustersApi(SherlockConfiguration)
     .apiV2ClustersSelectorGet(
       { selector: params.clusterName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.clusters.new.tsx
+++ b/app/routes/_layout.clusters.new.tsx
@@ -15,7 +15,7 @@ import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
 import { ClusterEditableFields } from "~/features/sherlock/clusters/edit/cluster-editable-fields";
 import { ClusterCreatableFields } from "~/features/sherlock/clusters/new/cluster-creatable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -41,7 +41,7 @@ export async function action({ request }: ActionArgs) {
   };
 
   return new ClustersApi(SherlockConfiguration)
-    .apiV2ClustersPost({ cluster: clusterRequest }, forwardIAP(request))
+    .apiV2ClustersPost({ cluster: clusterRequest }, handleIAP(request))
     .then(
       (cluster) => redirect(`/clusters/${cluster.name}`),
       makeErrorResponseReturner(clusterRequest)

--- a/app/routes/_layout.clusters.tsx
+++ b/app/routes/_layout.clusters.tsx
@@ -14,8 +14,8 @@ import { clusterSorter } from "~/features/sherlock/clusters/list/cluster-sorter"
 import { ListClusterButtonText } from "~/features/sherlock/clusters/list/list-cluster-button-text";
 import { matchCluster } from "~/features/sherlock/clusters/list/match-cluster";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export const handle = {
@@ -30,7 +30,7 @@ export const meta: V2_MetaFunction = () => [
 
 export async function loader({ request }: LoaderArgs) {
   return new ClustersApi(SherlockConfiguration)
-    .apiV2ClustersGet({}, forwardIAP(request))
+    .apiV2ClustersGet({}, handleIAP(request))
     .then((clusters) => clusters.sort(clusterSorter), errorResponseThrower);
 }
 

--- a/app/routes/_layout.environments.$environmentName.adjust-bulk-update-defaults.tsx
+++ b/app/routes/_layout.environments.$environmentName.adjust-bulk-update-defaults.tsx
@@ -20,7 +20,7 @@ import { chartReleaseSorter } from "~/features/sherlock/chart-releases/list/char
 import { SidebarSelectMultipleChartReleases } from "~/features/sherlock/chart-releases/set/sidebar-select-multiple-chart-releases";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
@@ -51,7 +51,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesGet(
       { environment: params.environmentName },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartReleases) => chartReleases.sort(chartReleaseSorter),
@@ -84,7 +84,7 @@ export async function action({ request, params }: ActionArgs) {
             includedInBulkChangesets: included,
           },
         },
-        forwardIAP(request)
+        handleIAP(request)
       )
     )
   ).then(

--- a/app/routes/_layout.environments.$environmentName.change-versions.tsx
+++ b/app/routes/_layout.environments.$environmentName.change-versions.tsx
@@ -28,7 +28,7 @@ import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-rel
 import { SidebarSelectMultipleChartReleases } from "~/features/sherlock/chart-releases/set/sidebar-select-multiple-chart-releases";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { SidebarFilterControlledList } from "../components/panel-structures/sidebar-filter-controlled-list";
@@ -64,7 +64,7 @@ export async function loader({ request, params }: LoaderArgs) {
   const preconfiguredOtherEnvironment = url.searchParams.get("from");
   return Promise.all([
     new EnvironmentsApi(SherlockConfiguration)
-      .apiV2EnvironmentsGet({}, forwardIAP(request))
+      .apiV2EnvironmentsGet({}, handleIAP(request))
       .then(
         (environments) => environments.sort(environmentSorter),
         errorResponseThrower
@@ -72,7 +72,7 @@ export async function loader({ request, params }: LoaderArgs) {
     new ChartReleasesApi(SherlockConfiguration)
       .apiV2ChartReleasesGet(
         { environment: params.environmentName },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .then(
         (chartReleases) => chartReleases.sort(chartReleaseSorter),
@@ -119,7 +119,7 @@ export async function action({ request, params }: ActionArgs) {
           environments: [changesetRequest],
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (changesets) =>

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.applied-changesets.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.applied-changesets.tsx
@@ -6,8 +6,8 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { useEnvironmentChartReleaseContext } from "~/routes/_layout.environments.$environmentName.chart-releases.$chartName";
 import { AppliedChangesetsPanel } from "../features/sherlock/changesets/list/applied-changesets-panel";
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderArgs) {
           offset: offset,
           limit: limit,
         },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     offset,

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.change-versions.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.change-versions.tsx
@@ -19,7 +19,7 @@ import {
   V2controllersChangesetPlanRequestChartReleaseEntry,
 } from "@sherlock-js-client/sherlock";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -56,7 +56,7 @@ export function loader({ request, params }: LoaderArgs) {
   const preconfiguredOtherEnvironment = url.searchParams.get("from");
   return Promise.all([
     new ChartReleasesApi(SherlockConfiguration)
-      .apiV2ChartReleasesGet({ chart: params.chartName }, forwardIAP(request))
+      .apiV2ChartReleasesGet({ chart: params.chartName }, handleIAP(request))
       .then(
         (chartReleases) =>
           Array.from(
@@ -72,13 +72,13 @@ export function loader({ request, params }: LoaderArgs) {
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -103,7 +103,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (changesets) =>

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.database-instance.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.database-instance.tsx
@@ -18,7 +18,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import { DatabaseInstancePanel } from "~/features/sherlock/database-instances/database-instance-panel";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -47,7 +47,7 @@ export async function loader({ request, params }: LoaderArgs) {
       {
         selector: `chart-release/${params.environmentName}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(() => null);
 }
@@ -66,7 +66,7 @@ export async function action({ request, params }: ActionArgs) {
         databaseInstance: databaseInstanceRequest,
         selector: `chart-release/${params.environmentName}/${params.chartName}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.delete.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.delete.tsx
@@ -3,7 +3,7 @@ import { NavLink, Params, useActionData } from "@remix-run/react";
 import { ChartReleasesApi } from "@sherlock-js-client/sherlock";
 import { runGha } from "~/features/github/run-gha";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { commitSession } from "~/session.server";
@@ -35,7 +35,7 @@ export async function action({ request, params }: ActionArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesSelectorDelete(
       { selector: `${params.environmentName}/${params.chartName}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.edit.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.edit.tsx
@@ -7,7 +7,7 @@ import {
 import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -49,7 +49,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.environmentName}/${params.chartName}`,
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.link-pagerduty.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.link-pagerduty.tsx
@@ -18,7 +18,7 @@ import {
 import { getPdAppIdFromEnv } from "~/components/logic/pagerduty-token";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -50,7 +50,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new PagerdutyIntegrationsApi(SherlockConfiguration)
-      .apiV2PagerdutyIntegrationsGet({}, forwardIAP(request))
+      .apiV2PagerdutyIntegrationsGet({}, handleIAP(request))
       .catch(errorResponseThrower),
     getPdAppIdFromEnv(),
   ]);
@@ -70,7 +70,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.environmentName}/${params.chartName}`,
         chartRelease: chartReleaseRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () =>

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.tsx
@@ -13,8 +13,8 @@ import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-rel
 import { ChartReleaseDetails } from "~/features/sherlock/chart-releases/view/chart-release-details";
 import { EnvironmentOfflineIcon } from "~/features/sherlock/environments/offline/environment-offline-icon";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -39,7 +39,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesSelectorGet(
       { selector: `${params.environmentName}/${params.chartName}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
@@ -25,7 +25,7 @@ import { ChartReleaseCreatableEnvironmentFields } from "~/features/sherlock/char
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import { ChartReleaseEditableFields } from "~/features/sherlock/chart-releases/edit/chart-release-editable-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -63,11 +63,11 @@ export async function loader({ request, params }: LoaderArgs) {
     new ChartsApi(SherlockConfiguration)
       .apiV2ChartsSelectorGet(
         { selector: params.chartName || "" },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartReleasesApi(SherlockConfiguration)
-      .apiV2ChartReleasesGet({ chart: params.chartName }, forwardIAP(request))
+      .apiV2ChartReleasesGet({ chart: params.chartName }, handleIAP(request))
       .then(
         (chartReleases) =>
           Array.from(
@@ -81,13 +81,13 @@ export async function loader({ request, params }: LoaderArgs) {
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
   ]);
@@ -110,7 +110,7 @@ export async function action({ request, params }: ActionArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesPost(
       { chartRelease: chartReleaseRequest },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {

--- a/app/routes/_layout.environments.$environmentName.chart-releases.add.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.add.tsx
@@ -15,8 +15,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { ChartColors } from "~/features/sherlock/charts/chart-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -43,13 +43,13 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new ChartsApi(SherlockConfiguration)
-      .apiV2ChartsGet({}, forwardIAP(request))
+      .apiV2ChartsGet({}, handleIAP(request))
       .then((charts) => charts.sort(chartSorter), errorResponseThrower),
     // We don't actually need the clusters here, but loading them here and passing
     // them down through via context means we won't be loading them repeatedly on
     // the next page if the user is browsing charts to deploy by clicking on them.
     new ClustersApi(SherlockConfiguration)
-      .apiV2ClustersGet({}, forwardIAP(request))
+      .apiV2ClustersGet({}, handleIAP(request))
       .then((clusters) => clusters.sort(clusterSorter), errorResponseThrower),
   ]);
 }

--- a/app/routes/_layout.environments.$environmentName.chart-releases.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.tsx
@@ -16,8 +16,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -44,7 +44,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesGet(
       { environment: params.environmentName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartReleases) => chartReleases.sort(chartReleaseSorter),

--- a/app/routes/_layout.environments.$environmentName.delete.tsx
+++ b/app/routes/_layout.environments.$environmentName.delete.tsx
@@ -9,7 +9,7 @@ import { runGha } from "~/features/github/run-gha";
 import { EnvironmentDeleteDescription } from "~/features/sherlock/environments/delete/environment-delete-description";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { commitSession } from "~/session.server";
@@ -39,7 +39,7 @@ export async function action({ request, params }: ActionArgs) {
   return environmentsApi
     .apiV2EnvironmentsSelectorGet(
       { selector: params.environmentName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (environment) => {
       if (environment.lifecycle === "dynamic") {
@@ -60,7 +60,7 @@ export async function action({ request, params }: ActionArgs) {
         return await environmentsApi
           .apiV2EnvironmentsSelectorDelete(
             { selector: params.environmentName || "" },
-            forwardIAP(request)
+            handleIAP(request)
           )
           .then(() => redirect("/environments"), makeErrorResponseReturner());
       }

--- a/app/routes/_layout.environments.$environmentName.edit.tsx
+++ b/app/routes/_layout.environments.$environmentName.edit.tsx
@@ -25,7 +25,7 @@ import { EnvironmentEditableFields } from "~/features/sherlock/environments/edit
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import { EnvironmentHelpCopy } from "~/features/sherlock/environments/environment-help-copy";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { makeUserSorter } from "~/features/sherlock/users/list/user-sorter";
@@ -55,10 +55,10 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new ClustersApi(SherlockConfiguration)
-      .apiV2ClustersGet({}, forwardIAP(request))
+      .apiV2ClustersGet({}, handleIAP(request))
       .then((clusters) => clusters.sort(clusterSorter), errorResponseThrower),
     new UsersApi(SherlockConfiguration)
-      .apiV2UsersGet({}, forwardIAP(request))
+      .apiV2UsersGet({}, handleIAP(request))
       .then(
         (users) => users.sort(makeUserSorter(getUserEmail(request))),
         errorResponseThrower
@@ -83,7 +83,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.environmentName || "",
         environment: environmentRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (environment) => redirect(`/environments/${environment.name}`),

--- a/app/routes/_layout.environments.$environmentName.link-pagerduty.tsx
+++ b/app/routes/_layout.environments.$environmentName.link-pagerduty.tsx
@@ -18,7 +18,7 @@ import {
 import { getPdAppIdFromEnv } from "~/components/logic/pagerduty-token";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -46,7 +46,7 @@ export const meta: V2_MetaFunction = ({ params }) => [
 export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     new PagerdutyIntegrationsApi(SherlockConfiguration)
-      .apiV2PagerdutyIntegrationsGet({}, forwardIAP(request))
+      .apiV2PagerdutyIntegrationsGet({}, handleIAP(request))
       .catch(errorResponseThrower),
     getPdAppIdFromEnv(),
   ]);
@@ -66,7 +66,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.environmentName || "",
         environment: environmentRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (environment) => redirect(`/environments/${environment.name}`),

--- a/app/routes/_layout.environments.$environmentName.schedule.tsx
+++ b/app/routes/_layout.environments.$environmentName.schedule.tsx
@@ -19,8 +19,8 @@ import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handl
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import { EnvironmentScheduleFields } from "~/features/sherlock/environments/offline/environment-schedule-fields";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { dateWithCustomISOString } from "~/helpers/date";
 import { getValidSession } from "~/helpers/get-valid-session.server";
@@ -71,7 +71,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.environmentName || "",
         environment: environmentRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (environment) => redirect(`/environments/${environment.name}`),

--- a/app/routes/_layout.environments.$environmentName.tsx
+++ b/app/routes/_layout.environments.$environmentName.tsx
@@ -18,7 +18,7 @@ import { EnvironmentOfflineIcon } from "~/features/sherlock/environments/offline
 import { EnvironmentDetails } from "~/features/sherlock/environments/view/environment-details";
 import {
   SherlockConfiguration,
-  forwardIAP,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { toTitleCase } from "~/helpers/strings";
 import { ProdFlag } from "../components/layout/prod-flag";
@@ -42,13 +42,13 @@ export async function loader({ request, params }: LoaderArgs) {
     new EnvironmentsApi(SherlockConfiguration)
       .apiV2EnvironmentsSelectorGet(
         { selector: params.environmentName || "" },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(errorResponseThrower),
     new ChartReleasesApi(SherlockConfiguration)
       .apiV2ChartReleasesSelectorGet(
         { selector: `${params.environmentName}/terraui` },
-        forwardIAP(request)
+        handleIAP(request)
       )
       .catch(() => null),
   ]);

--- a/app/routes/_layout.environments.new.tsx
+++ b/app/routes/_layout.environments.new.tsx
@@ -27,7 +27,7 @@ import { EnvironmentAdvancedCreatableFields } from "~/features/sherlock/environm
 import { EnvironmentCreatableFields } from "~/features/sherlock/environments/new/environment-creatable-fields";
 import { EnvironmentScheduleFields } from "~/features/sherlock/environments/offline/environment-schedule-fields";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { makeUserSorter } from "~/features/sherlock/users/list/user-sorter";
@@ -63,10 +63,10 @@ export async function loader({ request }: LoaderArgs) {
   return Promise.all([
     selfUserEmail,
     new ClustersApi(SherlockConfiguration)
-      .apiV2ClustersGet({}, forwardIAP(request))
+      .apiV2ClustersGet({}, handleIAP(request))
       .then((clusters) => clusters.sort(clusterSorter), errorResponseThrower),
     new UsersApi(SherlockConfiguration)
-      .apiV2UsersGet({}, forwardIAP(request))
+      .apiV2UsersGet({}, handleIAP(request))
       .then(
         (users) => users.sort(makeUserSorter(selfUserEmail)),
         errorResponseThrower
@@ -111,7 +111,7 @@ export async function action({ request }: ActionArgs) {
   return new EnvironmentsApi(SherlockConfiguration)
     .apiV2EnvironmentsPost(
       { environment: environmentRequest },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (environment) => {
       if (

--- a/app/routes/_layout.environments.tsx
+++ b/app/routes/_layout.environments.tsx
@@ -15,8 +15,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -36,7 +36,7 @@ export const meta: V2_MetaFunction = () => [
 
 export async function loader({ request }: LoaderArgs) {
   return new EnvironmentsApi(SherlockConfiguration)
-    .apiV2EnvironmentsGet({}, forwardIAP(request))
+    .apiV2EnvironmentsGet({}, handleIAP(request))
     .then(
       (environments) => environments.sort(environmentSorter),
       errorResponseThrower

--- a/app/routes/_layout.misc.tsx
+++ b/app/routes/_layout.misc.tsx
@@ -9,7 +9,7 @@ import {
 } from "~/components/logic/csrf-token";
 import { ThemeDropdown } from "~/components/logic/theme";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { getSession, sessionFields } from "~/session.server";
@@ -33,10 +33,10 @@ export async function loader({ request }: LoaderArgs) {
   return defer({
     beehiveVersion: process.env.BUILD_VERSION || "development",
     sherlockVersionPromise: sherlock
-      .versionGet(forwardIAP(request))
+      .versionGet(handleIAP(request))
       .then((versionResponse) => versionResponse),
     mySherlockUserPromise: sherlock
-      .myUserGet(forwardIAP(request))
+      .myUserGet(handleIAP(request))
       .then((myUserResponse) => myUserResponse),
     myGitHubUserPromise: octokit.users
       .getAuthenticated()

--- a/app/routes/_layout.pagerduty-integrations.$pagerdutyID.delete.tsx
+++ b/app/routes/_layout.pagerduty-integrations.$pagerdutyID.delete.tsx
@@ -8,7 +8,7 @@ import { ActionBox } from "~/components/panel-structures/action-box";
 import { PagerdutyIntegrationDeleteDescription } from "~/features/sherlock/pagerduty-integrations/delete/pagerduty-integration-delete-description";
 import { PagerdutyIntegrationColors } from "~/features/sherlock/pagerduty-integrations/pagerduty-integration-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
@@ -35,7 +35,7 @@ export async function action({ request, params }: ActionArgs) {
   return new PagerdutyIntegrationsApi(SherlockConfiguration)
     .apiV2PagerdutyIntegrationsSelectorDelete(
       { selector: `pd-id/${params.pagerdutyID}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       () => redirect("/pagerduty-integrations"),

--- a/app/routes/_layout.pagerduty-integrations.$pagerdutyID.tsx
+++ b/app/routes/_layout.pagerduty-integrations.$pagerdutyID.tsx
@@ -12,8 +12,8 @@ import { ItemDetails } from "~/components/panel-structures/item-details";
 import { PagerdutyIntegrationColors } from "~/features/sherlock/pagerduty-integrations/pagerduty-integration-colors";
 import { PagerdutyIntegrationDetails } from "~/features/sherlock/pagerduty-integrations/view/pagerduty-integration-details";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { ProdFlag } from "../components/layout/prod-flag";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
@@ -39,7 +39,7 @@ export async function loader({ request, params }: LoaderArgs) {
       {
         selector: `pd-id/${params.pagerdutyID}`,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.pagerduty-integrations.tsx
+++ b/app/routes/_layout.pagerduty-integrations.tsx
@@ -9,8 +9,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { PagerdutyIntegrationColors } from "~/features/sherlock/pagerduty-integrations/pagerduty-integration-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -29,7 +29,7 @@ export const meta: V2_MetaFunction = () => [
 
 export async function loader({ request }: LoaderArgs) {
   return new PagerdutyIntegrationsApi(SherlockConfiguration)
-    .apiV2PagerdutyIntegrationsGet({}, forwardIAP(request))
+    .apiV2PagerdutyIntegrationsGet({}, handleIAP(request))
     .catch(errorResponseThrower);
 }
 

--- a/app/routes/_layout.review-changesets.tsx
+++ b/app/routes/_layout.review-changesets.tsx
@@ -25,7 +25,7 @@ import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-rel
 import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { safeRedirectPath } from "~/helpers/validate";
@@ -59,7 +59,7 @@ export async function loader({ request }: LoaderArgs) {
   return Promise.all(
     changesetIDs.map(async (id) => {
       const changeset = await changesetsApi
-        .apiV2ChangesetsSelectorGet({ selector: id }, forwardIAP(request))
+        .apiV2ChangesetsSelectorGet({ selector: id }, handleIAP(request))
         .catch(errorResponseThrower);
       // We need two levels deep, not one like Sherlock gives us by default,
       // so we fill the chartReleaseInfo ourselves with a followup request.
@@ -68,7 +68,7 @@ export async function loader({ request }: LoaderArgs) {
           {
             selector: changeset.chartRelease || "",
           },
-          forwardIAP(request)
+          handleIAP(request)
         )
         .catch(errorResponseThrower);
       return changeset;
@@ -87,7 +87,7 @@ export async function action({ request }: ActionArgs) {
           .getAll("changeset")
           .filter((value): value is string => typeof value === "string"),
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async () => {
       if (

--- a/app/routes/_layout.trigger-incident.$environmentName.chart-releases.$chartName.tsx
+++ b/app/routes/_layout.trigger-incident.$environmentName.chart-releases.$chartName.tsx
@@ -19,7 +19,7 @@ import { OutsetPanel } from "~/components/layout/outset-panel";
 import { ActionBox } from "~/components/panel-structures/action-box";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -52,7 +52,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesSelectorGet(
       { selector: `${params.environmentName}/${params.chartName}` },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 };
@@ -71,7 +71,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: `${params.environmentName}/${params.chartName}`,
         summary: summaryRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then((response) => {
       console.log(response);

--- a/app/routes/_layout.trigger-incident.$environmentName.chart-releases.tsx
+++ b/app/routes/_layout.trigger-incident.$environmentName.chart-releases.tsx
@@ -9,8 +9,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -35,7 +35,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesGet(
       { environment: params.environmentName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartReleases) =>

--- a/app/routes/_layout.trigger-incident.$environmentName.general-incident.tsx
+++ b/app/routes/_layout.trigger-incident.$environmentName.general-incident.tsx
@@ -9,7 +9,7 @@ import { OutsetPanel } from "~/components/layout/outset-panel";
 import { ActionBox } from "~/components/panel-structures/action-box";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
@@ -50,7 +50,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.environmentName || "",
         summary: summaryRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then((response) => {
       console.log(response);

--- a/app/routes/_layout.trigger-incident.$environmentName.tsx
+++ b/app/routes/_layout.trigger-incident.$environmentName.tsx
@@ -13,8 +13,8 @@ import { ItemDetails } from "~/components/panel-structures/item-details";
 import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-release-colors";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -35,7 +35,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new EnvironmentsApi(SherlockConfiguration)
     .apiV2EnvironmentsSelectorGet(
       { selector: params.environmentName || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.trigger-incident.tsx
+++ b/app/routes/_layout.trigger-incident.tsx
@@ -9,8 +9,8 @@ import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
 import { InteractiveList } from "~/components/panel-structures/interactive-list";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { PanelErrorBoundary } from "../errors/components/error-boundary";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -29,7 +29,7 @@ export const meta: V2_MetaFunction = () => [
 
 export async function loader({ request }: LoaderArgs) {
   return new EnvironmentsApi(SherlockConfiguration)
-    .apiV2EnvironmentsGet({}, forwardIAP(request))
+    .apiV2EnvironmentsGet({}, handleIAP(request))
     .then(
       (environments) =>
         environments

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -12,7 +12,7 @@ import { SelfUserContext } from "~/contexts";
 import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { commitSession, getSession, sessionFields } from "~/session.server";
@@ -25,7 +25,7 @@ export async function loader({ request }: LoaderArgs) {
     session.get(sessionFields.flashNotifications) || null;
 
   const selfUser = await new UsersApi(SherlockConfiguration)
-    .apiV2ProceduresUsersMeGet(forwardIAP(request))
+    .apiV2ProceduresUsersMeGet(handleIAP(request))
     .catch(errorResponseThrower);
 
   return json(

--- a/app/routes/_layout.users.$userEmail.edit.tsx
+++ b/app/routes/_layout.users.$userEmail.edit.tsx
@@ -10,7 +10,7 @@ import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { FormErrorDisplay } from "~/errors/components/form-error-display";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { UserEditableFields } from "~/features/sherlock/users/edit/user-editable-fields";
@@ -47,7 +47,7 @@ export async function action({ request, params }: ActionArgs) {
         selector: params.userEmail || "",
         user: userRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(() =>
       api.apiV2ProceduresUsersLinkGithubPost(
@@ -56,7 +56,7 @@ export async function action({ request, params }: ActionArgs) {
             githubAccessToken: session.get(sessionFields.githubAccessToken),
           },
         },
-        forwardIAP(request)
+        handleIAP(request)
       )
     )
     .then(

--- a/app/routes/_layout.users.$userEmail.tsx
+++ b/app/routes/_layout.users.$userEmail.tsx
@@ -12,8 +12,8 @@ import { ItemDetails } from "~/components/panel-structures/item-details";
 import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { UserColors } from "~/features/sherlock/users/user-colors";
 import { UserDetails } from "~/features/sherlock/users/view/user-details";
@@ -33,7 +33,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new UsersApi(SherlockConfiguration)
     .apiV2UsersSelectorGet(
       { selector: params.userEmail || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .catch(errorResponseThrower);
 }

--- a/app/routes/_layout.users.tsx
+++ b/app/routes/_layout.users.tsx
@@ -16,8 +16,8 @@ import { InteractiveList } from "~/components/panel-structures/interactive-list"
 import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { ListUserButtonText } from "~/features/sherlock/users/list/list-user-button-text";
 import { matchUser } from "~/features/sherlock/users/list/matchUser";
@@ -41,9 +41,9 @@ export async function loader({ request }: LoaderArgs) {
   const api = new UsersApi(SherlockConfiguration);
   const [selfUser, allUsers] = await Promise.all([
     api
-      .apiV2ProceduresUsersMeGet(forwardIAP(request))
+      .apiV2ProceduresUsersMeGet(handleIAP(request))
       .catch(errorResponseThrower),
-    api.apiV2UsersGet({}, forwardIAP(request)).catch(errorResponseThrower),
+    api.apiV2UsersGet({}, handleIAP(request)).catch(errorResponseThrower),
   ]);
   return {
     selfEmail: selfUser.email,

--- a/app/routes/api.argocd.badge.ts
+++ b/app/routes/api.argocd.badge.ts
@@ -1,6 +1,6 @@
 import { json, LoaderArgs } from "@remix-run/node";
 import https from "https";
-import { forwardIAP } from "~/features/sherlock/sherlock.server";
+import { handleIAP } from "~/features/sherlock/sherlock.server";
 
 // IAP pass-through to ArgoCD's /badge endpoint. This endpoint on ArgoCD doesn't
 // require any authentication, but we wrap it in IAP so we actually do still
@@ -20,7 +20,7 @@ export async function loader({ request }: LoaderArgs) {
       "https://ap-argocd.dsp-devops.broadinstitute.org"
     }/api/badge?name=${new URL(request.url).searchParams.get("name")}`,
     {
-      ...forwardIAP(request),
+      ...handleIAP(request),
       // We don't do TLS hostname validation when the hostname is in the
       // same cluster and is using TLS.
       // @ts-expect-error

--- a/app/routes/api.pagerduty.receive-install.ts
+++ b/app/routes/api.pagerduty.receive-install.ts
@@ -2,8 +2,8 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { PagerdutyIntegrationsApi } from "@sherlock-js-client/sherlock";
 import { verifySessionPagerdutyToken } from "~/components/logic/pagerduty-token";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { getSession } from "~/session.server";
 import { errorResponseThrower } from "../errors/helpers/error-response-handlers";
@@ -48,7 +48,7 @@ export async function loader({ request }: LoaderArgs) {
               type: k.type,
             },
           },
-          forwardIAP(request)
+          handleIAP(request)
         )
         .catch(errorResponseThrower)
     )

--- a/app/routes/api.sherlock.set-environment-offline.ts
+++ b/app/routes/api.sherlock.set-environment-offline.ts
@@ -7,8 +7,8 @@ import { json } from "react-router";
 import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
 import { runGha } from "~/features/github/run-gha";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
 import { commitSession } from "~/session.server";
@@ -27,7 +27,7 @@ export async function action({ request }: ActionArgs) {
         selector: typeof environmentName === "string" ? environmentName : "",
         environment: environmentRequest,
       },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(async (environment) => {
       await runGha(

--- a/app/routes/r.app-version.$.ts
+++ b/app/routes/r.app-version.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { AppVersionsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new AppVersionsApi(SherlockConfiguration)
     .apiV2AppVersionsSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (appVersion) =>

--- a/app/routes/r.changeset.$.ts
+++ b/app/routes/r.changeset.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { ChangesetsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ChangesetsApi(SherlockConfiguration)
     .apiV2ChangesetsSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (changeset) => redirect(`/review-changesets?changeset=${changeset.id}`),

--- a/app/routes/r.chart-release.$.ts
+++ b/app/routes/r.chart-release.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { ChartReleasesApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartRelease) =>

--- a/app/routes/r.chart-version.$.ts
+++ b/app/routes/r.chart-version.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { ChartVersionsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ChartVersionsApi(SherlockConfiguration)
     .apiV2ChartVersionsSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (chartVersion) =>

--- a/app/routes/r.chart.$.ts
+++ b/app/routes/r.chart.$.ts
@@ -2,16 +2,13 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { ChartsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ChartsApi(SherlockConfiguration)
-    .apiV2ChartsSelectorGet(
-      { selector: params["*"] || "" },
-      forwardIAP(request)
-    )
+    .apiV2ChartsSelectorGet({ selector: params["*"] || "" }, handleIAP(request))
     .then(
       (chart) => redirect(`/charts/${chart.name}`),
       makeErrorResponseReturner()

--- a/app/routes/r.cluster.$.ts
+++ b/app/routes/r.cluster.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { ClustersApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ClustersApi(SherlockConfiguration)
     .apiV2ClustersSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (cluster) => redirect(`/clusters/${cluster.name}`),

--- a/app/routes/r.endpoint.$.ts
+++ b/app/routes/r.endpoint.$.ts
@@ -2,7 +2,7 @@ import { json, LoaderArgs, redirect } from "@remix-run/node";
 import { ChartReleasesApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 import { safeRedirectPath } from "~/helpers/validate";
@@ -11,7 +11,7 @@ export async function loader({ request, params }: LoaderArgs) {
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then((chartRelease) => {
       const protocol =

--- a/app/routes/r.environment.$.ts
+++ b/app/routes/r.environment.$.ts
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { EnvironmentsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new EnvironmentsApi(SherlockConfiguration)
     .apiV2EnvironmentsSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (environment) => redirect(`/environments/${environment.name}`),

--- a/app/routes/r.git.$.ts
+++ b/app/routes/r.git.$.ts
@@ -2,16 +2,13 @@ import { json, LoaderArgs, redirect } from "@remix-run/node";
 import { ChartsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
+  handleIAP,
   SherlockConfiguration,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new ChartsApi(SherlockConfiguration)
-    .apiV2ChartsSelectorGet(
-      { selector: params["*"] || "" },
-      forwardIAP(request)
-    )
+    .apiV2ChartsSelectorGet({ selector: params["*"] || "" }, handleIAP(request))
     .then(
       (chart) =>
         chart.appImageGitRepo

--- a/app/routes/r.pagerduty-integration.$.tsx
+++ b/app/routes/r.pagerduty-integration.$.tsx
@@ -2,15 +2,15 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { PagerdutyIntegrationsApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   return new PagerdutyIntegrationsApi(SherlockConfiguration)
     .apiV2PagerdutyIntegrationsSelectorGet(
       { selector: params["*"] || "" },
-      forwardIAP(request)
+      handleIAP(request)
     )
     .then(
       (pagerdutyIntegration) =>

--- a/app/routes/r.user.$.ts
+++ b/app/routes/r.user.$.ts
@@ -2,22 +2,22 @@ import { LoaderArgs, redirect } from "@remix-run/node";
 import { UsersApi } from "@sherlock-js-client/sherlock";
 import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
 import {
-  forwardIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 
 export async function loader({ request, params }: LoaderArgs) {
   const search = params["*"] || "";
   if (search === "me") {
     return new UsersApi(SherlockConfiguration)
-      .apiV2ProceduresUsersMeGet(forwardIAP(request))
+      .apiV2ProceduresUsersMeGet(handleIAP(request))
       .then(
         (user) => redirect(`/users/${user.email}`),
         makeErrorResponseReturner()
       );
   } else {
     return new UsersApi(SherlockConfiguration)
-      .apiV2UsersSelectorGet({ selector: search }, forwardIAP(request))
+      .apiV2UsersSelectorGet({ selector: search }, handleIAP(request))
       .then(
         (user) => redirect(`/users/${user.email}`),
         () => redirect(`/users?search=${search.split("/").pop()}`)


### PR DESCRIPTION
Here's what now does the IAP handling ([diff](https://github.com/broadinstitute/beehive/pull/205/files#diff-d434c39fe70920ba7ba87230f9c12b19b53320bb7b12916db113b330cdebce60)):
```typescript
export function handleIAP(request: Request): RequestInit {
  if (request.headers.has(IapJwtHeader)) {
    // Request looks like post-IAP, so forward the header
    return { headers: { [IapJwtHeader]: request.headers.get(IapJwtHeader)! } };
  }
  if (
    process.env.NODE_ENV !== "production" &&
    process.env.SHERLOCK_BASE_URL?.startsWith("https") &&
    process.env.IAP_TOKEN
  ) {
    // Not in production mode, talking to a real instance, and we were given a token, so use it
    return { headers: { Authorization: `Bearer ${process.env.IAP_TOKEN}` } };
  }
  return {};
}
```

What does this mean? You can do something like this:

```bash
IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock.dsp-devops.broadinstitute.org' npm run dev
```

This seems generally just super helpful. The line count in the PR is due to renaming the function from `forwardIAP` to `handleIAP`.

Also, can I just say I _adore_ the fact that this was this easy to do. Server-side requests for the win, we can literally just read from `process.env` and it doesn't skip a beat. Server-side means we don't need to worry about letting `http://localhost:3000` through Sherlock's CORS either.

## Testing

This is a local dev thing and it works. Folks are welcome to try it if they like, this is easier to do than setting up a local Sherlock with data.

Did deploy the image to Beehive dev to check that there weren't issues forwarding post-IAP like before.

## Risk

None, I think. Running even a malicious Beehive against a remote Sherlock isn't a security issue because Sherlock's API is what does the validation -- you're not doing anything you wouldn't already be able to do with `curl`.