### PR TITLE
[DDO-2878] Fix deletion redirect

### DIFF
--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
@@ -52,14 +52,11 @@ export async function action({ request, params }: ActionArgs) {
           "sync your BEE"
         );
       }
-      return redirect(
-        `/charts/${params.chartName}/chart-releases/${params.chartReleaseName}`,
-        {
-          headers: {
-            "Set-Cookie": await commitSession(session),
-          },
-        }
-      );
+      return redirect(`/charts/${params.chartName}/chart-releases`, {
+        headers: {
+          "Set-Cookie": await commitSession(session),
+        },
+      });
     }, makeErrorResponseReturner());
 }
 

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx
@@ -53,7 +53,7 @@ export async function action({ request, params }: ActionArgs) {
         );
       }
       return redirect(
-        `/environments/${params.environmentName}/chart-releases`,
+        `/charts/${params.chartName}/chart-releases/${params.chartReleaseName}`,
         {
           headers: {
             "Set-Cookie": await commitSession(session),


### PR DESCRIPTION
Copy paste error on my part -- see that the file name has `$chartName` in it but not `$environmentName`, so the existing redirect's usage of `params.environmentName` was resolving to an empty string (and Sherlock was 404-ing on an empty string). The right thing to do is redirect to the list of chart releases for the chart, not for an environment that might not exist for cluster-only releases.

> app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.delete.tsx

```diff
- `/environments/${params.environmentName}/chart-releases`
+ `/charts/${params.chartName}/chart-releases`
```

## Testing

Works locally.

## Risk

This didn't affect the deletion, just which page you were sent to upon completion from this specific page.