### PR TITLE
[DDO-2929] Fix revert/recreate on mobile

### DIFF
--- a/app/features/sherlock/changesets/list/changeset-entry.tsx
+++ b/app/features/sherlock/changesets/list/changeset-entry.tsx
@@ -533,7 +533,7 @@ export const ChangesetEntry: React.FunctionComponent<{
         </div>
       )}
       {(changeset.supersededAt || changeset.appliedAt) && (
-        <div className="flex flex-row justify-between items-end pt-4">
+        <div className="flex flex-col laptop:flex-row gap-2 justify-between items-end pt-4">
           {changeset.supersededAt && (
             <h1 className="text-2xl font-light">
               This proposed change is out of date as of{" "}


### PR DESCRIPTION
Kinda forgot that Beehive ostensibly supports mobile devices for a moment.

Super tiny change, just goes from 

![Screenshot 2023-06-27 at 6 11 39 PM](https://github.com/broadinstitute/beehive/assets/29168264/c54013bb-fe31-4a93-9080-665a22359369)

to

![Screenshot 2023-06-27 at 6 11 51 PM](https://github.com/broadinstitute/beehive/assets/29168264/e009d487-07ba-47cd-ba4f-b95bc5d10efe)
