### PR TITLE
[DDO-2940] Fix environment name regex

### DIFF
--- a/app/features/sherlock/environments/new/environment-creatable-fields.tsx
+++ b/app/features/sherlock/environments/new/environment-creatable-fields.tsx
@@ -136,7 +136,7 @@ export const EnvironmentCreatableFields: React.FunctionComponent<
             }
             required={lifecycle !== "dynamic"}
             value={name}
-            pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+            pattern="[a-z0-9]([\-a-z0-9]*[a-z0-9])?"
             onChange={(e) => setName(e.currentTarget.value)}
           />
         </label>


### PR DESCRIPTION
Maybe I should make Sherlock more opinionated here but regardless this Regex is considered invalid by Chrome even though Regexr seemed fine with it. Whatever.

## Testing 

Go to https://beehive.dsp-devops.broadinstitute.org/environments/new, open your browser console, and then type in the name field. You'll see an invalid regex error. Edit the pattern from the browser console to backslash the `-` in the character class to include the hyphen and the error will be resolved (the field will correctly flag capitalized inputs as invalid).

## Risk

None