### PR TITLE
[DDO-2950] Tweak Beehive homepage

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -37,7 +37,7 @@ export default function Route() {
         <h1 className="text-4xl tablet:text-5xl laptop:text-7xl desktop:text-8xl font-extralight laptop:font-thin shrink-0 text-center text-color-header-text min-h-0 mt-4">
           Welcome to Beehive
         </h1>
-        <span className="text-lg text-center">
+        {/* <span className="text-lg text-center">
           <b className="font-semibold">New!</b> The{" "}
           <NavLink
             to="/apps"
@@ -46,56 +46,50 @@ export default function Route() {
             Apps page
           </NavLink>{" "}
           is here to help with independent releases!
-        </span>
+        </span> */}
       </div>
       <div className="flex flex-wrap justify-center w-full max-w-7xl m-auto min-h-0 items-center">
         <div className="flex flex-wrap justify-center w-full max-w-7xl m-auto min-h-0 items-center">
           <IndexNavButton
             to="/environments"
-            title="Environments"
+            title="Update BEEs"
             className="border-color-environment-border h-52"
           >
-            Full access to entire environments, including BEEs and BEE templates
+            + Other Environments
           </IndexNavButton>
           <IndexNavButton
             to="/apps"
-            title="Apps"
+            title="Deploy to Prod"
             className="border-color-chart-border h-52"
           >
-            Deploy new versions of your apps to alpha, staging, and production
+            + Alpha and Staging
           </IndexNavButton>
         </div>
         <div className="flex flex-wrap justify-center w-full max-w-7xl m-auto min-h-0 items-center">
-          <IndexNavButton
-            to="/clusters"
-            title="Clusters"
-            className="border-color-cluster-border h-36"
-          >
-            Browse Kubernetes clusters containing our deployments
-          </IndexNavButton>
           <IndexNavButton
             to="/trigger-incident/prod"
             title="Trigger Incident"
             className="border-color-neutral-soft-border h-36"
           >
-            Page someone about a problem with production Terra
-          </IndexNavButton>
-          <IndexNavButton
-            to="/charts"
-            title="Charts"
-            className="border-color-chart-border h-36"
-          >
-            Browse Helm Charts that deploy apps and infrastructure alike
+            Page the On-Call Engineer
           </IndexNavButton>
         </div>
       </div>
       <div className="flex flex-col items-center laptop:flex-row gap-2 justify-center font-light">
+        <NavLink to="/clusters" prefetch="intent">
+          Clusters
+        </NavLink>
+        <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/users" prefetch="intent">
-          View Users
+          Users
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/pagerduty-integrations" prefetch="intent">
-          Manage PagerDuty
+          PagerDuty
+        </NavLink>
+        <span className="hidden laptop:inline laptop:last:hidden">•</span>
+        <NavLink to="/charts" prefetch="intent">
+          Charts
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/misc" prefetch="intent">

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -93,7 +93,7 @@ export default function Route() {
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/r" prefetch="intent">
-          Redirects
+          Short-Links
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/misc" prefetch="intent">

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -92,6 +92,10 @@ export default function Route() {
           Charts
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
+        <NavLink to="/r" prefetch="intent">
+          Redirects
+        </NavLink>
+        <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/misc" prefetch="intent">
           Misc
         </NavLink>

--- a/app/routes/r.README.md
+++ b/app/routes/r.README.md
@@ -2,9 +2,11 @@ The endpoints here effectively allow short-links to different Sherlock data type
 
 The basic construction is like `/r/$type/$selector`, where the selector gets resolved directly by Sherlock and translated by Beehive to whatever page makes the most sense:
 
+- [`/r/environment/prod`](/r/environment/prod)
 - [`/r/chart/beehive`](/r/chart/beehive)
 - [`/r/cluster/1`](/r/cluster/1)
 - [`/r/chart-release/prod/sam`](/r/chart-release/prod/sam)
+- [`/r/app-version/sam/v0.0.103`](/r/app-version/sam/v0.0.103)
 
 There's also a special `/r/git/$selector` that redirects to the app image GitHub repo for a given chart.
 
@@ -12,4 +14,4 @@ There's also a special `/r/endpoint/$selector` that redirects to the endpoint fo
 
 There's also a special `/r/user/$selector` that attempts to resolve the User selector and falls back to a simple search over all users.
 
-It's helpful to use these with the `broad.io/beehive` shortlink, like `broad.io/beehive/r/environment/prod`.
+It's helpful to use these with the `broad.io/beehive` short-link, like `broad.io/beehive/r/environment/prod`.

--- a/app/routes/r.README.md
+++ b/app/routes/r.README.md
@@ -1,3 +1,4 @@
+<div className="text-color-body-text p-6">
 The endpoints here effectively allow short-links to different Sherlock data types in Beehive.
 
 The basic construction is like `/r/$type/$selector`, where the selector gets resolved directly by Sherlock and translated by Beehive to whatever page makes the most sense:
@@ -15,3 +16,5 @@ There's also a special `/r/endpoint/$selector` that redirects to the endpoint fo
 There's also a special `/r/user/$selector` that attempts to resolve the User selector and falls back to a simple search over all users.
 
 It's helpful to use these with the `broad.io/beehive` short-link, like `broad.io/beehive/r/environment/prod`.
+
+</div>

--- a/app/routes/r.README.md
+++ b/app/routes/r.README.md
@@ -11,3 +11,5 @@ There's also a special `/r/git/$selector` that redirects to the app image GitHub
 There's also a special `/r/endpoint/$selector` that redirects to the endpoint for a given chart instance.
 
 There's also a special `/r/user/$selector` that attempts to resolve the User selector and falls back to a simple search over all users.
+
+It's helpful to use these with the `broad.io/beehive` shortlink, like `broad.io/beehive/r/environment/prod`.

--- a/app/routes/r.app.$.ts
+++ b/app/routes/r.app.$.ts
@@ -1,0 +1,17 @@
+import type { LoaderArgs } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { ChartsApi } from "@sherlock-js-client/sherlock";
+import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
+import {
+  SherlockConfiguration,
+  handleIAP,
+} from "~/features/sherlock/sherlock.server";
+
+export async function loader({ request, params }: LoaderArgs) {
+  return new ChartsApi(SherlockConfiguration)
+    .apiV2ChartsSelectorGet({ selector: params["*"] || "" }, handleIAP(request))
+    .then(
+      (chart) => redirect(`/apps/${chart.name}`),
+      makeErrorResponseReturner()
+    );
+}


### PR DESCRIPTION
1. Hide the "new" banner text (keep it commented for when something launches)
2. Hide Clusters and Charts buttons
3. Make Environments button reference BEEs
4. Make Apps button reference Deployment
5. Add a link to the redirects feature to the homepage
6. Make `/r/apps/<chart-name>` work as expected

![Screenshot 2023-07-11 at 12 24 43 PM](https://github.com/broadinstitute/beehive/assets/29168264/91bec57e-f3fb-4045-80a0-29cab3bee875)
