### PR TITLE
[DDO-2952] Fix version history link

### DIFF
--- a/app/features/sherlock/chart-releases/view/app-instance-popover-contents.tsx
+++ b/app/features/sherlock/chart-releases/view/app-instance-popover-contents.tsx
@@ -55,7 +55,7 @@ export const AppInstancePopoverContents: React.FunctionComponent<{
       chartRelease={chartRelease}
       showChips={false}
       toChangeVersions={`/environments/${chartRelease.environment}/chart-releases/${chartRelease.chart}/change-versions`}
-      toVersionHistory={`/environments/${chartRelease.environment}/chart-releases/${chartRelease.chart}/version-history`}
+      toVersionHistory={`/environments/${chartRelease.environment}/chart-releases/${chartRelease.chart}/applied-changesets`}
     />
   </>
 );


### PR DESCRIPTION
Everywhere else in the UI correctly references `/applied-changesets`, because this is a popover it works differently (has to use absolute path) so this slipped through