### PR TITLE
[DDO-2994] Pass changeset IDs to sync-relase.yaml

### DIFF
--- a/app/routes/_layout.review-changesets.tsx
+++ b/app/routes/_layout.review-changesets.tsx
@@ -1,9 +1,5 @@
-import {
-  ActionArgs,
-  LoaderArgs,
-  redirect,
-  V2_MetaFunction,
-} from "@remix-run/node";
+import type { ActionArgs, LoaderArgs, V2_MetaFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 import {
   useActionData,
   useLoaderData,
@@ -25,8 +21,8 @@ import { ChartReleaseColors } from "~/features/sherlock/chart-releases/chart-rel
 import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
 import { EnvironmentColors } from "~/features/sherlock/environments/environment-colors";
 import {
-  handleIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { safeRedirectPath } from "~/helpers/validate";
 import { commitSession } from "~/session.server";


### PR DESCRIPTION
Take advantage of https://github.com/broadinstitute/terra-github-workflows/pull/93. We already have a stupid/simple mechanism for telling the Remix action which chart release names aren't templates and should be actually synced... so I just copied that to pass back a list of changeset IDs that aren't templates. The alternative would be a bunch of backend queries or passing some different value in a list and correlating it, so this is just easier.

## Testing

I knew the action itself worked per https://github.com/broadinstitute/terra-github-workflows/pull/93, and I knew that the request was properly-formed per Beehive's logging (it dumps the request body)... 

So I ran this branch's Beehive against Sherlock's production instance (safer than deploying this branch into Beehive prod outright). It worked! The screenshot looks the same as https://github.com/broadinstitute/terra-github-workflows/pull/93 but this time the GHA was initiated through Beehive rather than manually.

![Screenshot 2023-07-28 at 11 15 17 AM](https://github.com/broadinstitute/beehive/assets/29168264/f3f2ae1f-6e89-431d-9c40-bba32b37e8d2)

## Risk

Very low IMO