### PR TITLE
[DDO-2989] One more instance of Beehive hitting the v2 user API

### DIFF
--- a/app/routes/r.user.$.ts
+++ b/app/routes/r.user.$.ts
@@ -9,7 +9,7 @@ import {
 export async function loader({ request, params }: LoaderArgs) {
   const search = params["*"] || "";
   return new UsersApi(SherlockConfiguration)
-    .apiV2UsersSelectorGet({ selector: search }, handleIAP(request))
+    .apiUsersV3SelectorGet({ selector: search }, handleIAP(request))
     .then(
       (user) => redirect(`/users/${user.email}`),
       () => redirect(`/users?search=${search.split("/").pop()}`),


### PR DESCRIPTION
Problem of having deprecated APIs in your client library is that they still typecheck :/ messed this one up; should just call the other method. Does the same thing, this one just works a little better (it handles `me` and `self` and stuff better)

## Testing

Ran locally, not much to test, it works.

## Risk

None