### PR TITLE
Experimenting with Software Catalog for Foundation - Add foundation.yaml

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: beehive
+  description: |
+    Beehive is a UI for managing DSPs kubernetes deployments in both BEE and live environments
+  tags:
+    - typescript
+    - remix
+    - beehive
+    - kubernetes
+    - dsp-devops
+spec:
+  type: service
+  lifecycle: production
+  owner: dsp-devops


### PR DESCRIPTION
I'm experimenting with [backstage](https://backstage.spotify.com/) for Foundation purposes and need some real services to be able to try features out on my dev instance so I'm using sherlock and beehive. This metadata file is what enables services to be registered in the foundation service catalog

This is a 0 zero risk PR, functional change just adds a project metadata file for foundation to consume.