### PR TITLE
[DDO-3051] Improve "Review Version changes" UX

### DIFF
--- a/app/features/sherlock/changesets/list/applied-changesets-panel.tsx
+++ b/app/features/sherlock/changesets/list/applied-changesets-panel.tsx
@@ -38,7 +38,6 @@ export const AppliedChangesetsPanel: React.FunctionComponent<{
               changeset={changeset}
               key={index}
               disableTitle={true}
-              fadeIfUnappliable={false}
               startMinimized={true}
             />
           )}

--- a/app/features/sherlock/changesets/list/changeset-entry.tsx
+++ b/app/features/sherlock/changesets/list/changeset-entry.tsx
@@ -8,6 +8,7 @@ import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
 import type { PanelSize } from "~/helpers/panel-size";
 import { panelSizeToInnerClassName } from "~/helpers/panel-size";
 import { ChartReleaseColors } from "../../chart-releases/chart-release-colors";
+import { ChartReleaseLinkChip } from "../../chart-releases/chart-release-link-chip";
 import { ChartLinkChip } from "../../charts/chart-link-chip";
 import { CiRunResourceStatusWidget } from "../../ci/view/ci-run-resource-status-button";
 import {
@@ -21,7 +22,6 @@ export const ChangesetEntry: React.FunctionComponent<{
   size?: PanelSize;
   changeset: V2controllersChangeset | SerializeFrom<V2controllersChangeset>;
   disableTitle?: boolean;
-  fadeIfUnappliable?: boolean;
   includedCheckboxValue?: boolean;
   setIncludedCheckboxValue?: (value: boolean) => void;
   startMinimized?: boolean;
@@ -29,7 +29,6 @@ export const ChangesetEntry: React.FunctionComponent<{
   size = "two-thirds",
   changeset,
   disableTitle = false,
-  fadeIfUnappliable = true,
   includedCheckboxValue,
   setIncludedCheckboxValue,
   startMinimized = false,
@@ -134,11 +133,14 @@ export const ChangesetEntry: React.FunctionComponent<{
         </button>
       </div>
       {disableTitle || minimized || (
-        <div
-          className={`pt-2 flex flex-row gap-3 max-h-full flex-wrap ${
-            appliable ? "" : "opacity-50 pointer-events-none"
-          }`}
-        >
+        <div className="pt-2 flex flex-row gap-3 max-h-full flex-wrap">
+          {changeset.chartReleaseInfo?.name && (
+            <ChartReleaseLinkChip
+              chartRelease={changeset.chartReleaseInfo.name}
+              chart={changeset.chartReleaseInfo.chart}
+              environment={changeset.chartReleaseInfo.environment}
+            />
+          )}
           {changeset.chartReleaseInfo?.chart && (
             <ChartLinkChip chart={changeset.chartReleaseInfo?.chart} />
           )}
@@ -168,11 +170,7 @@ export const ChangesetEntry: React.FunctionComponent<{
         />
       )}
       {minimized || (
-        <div
-          className={`overflow-x-auto grid grid-cols-2 pt-2 gap-y-1 gap-x-4 ${
-            !appliable && fadeIfUnappliable ? "opacity-50" : ""
-          }`}
-        >
+        <div className="overflow-x-auto grid grid-cols-2 pt-2 gap-y-1 gap-x-4">
           <h2 className="font-medium text-2xl border-b border-color-divider-line pb-1">
             {appliable ? "Current" : "Before"}
           </h2>

--- a/app/features/sherlock/chart-releases/chart-release-link-chip.tsx
+++ b/app/features/sherlock/chart-releases/chart-release-link-chip.tsx
@@ -4,14 +4,18 @@ import { ChartReleaseColors } from "./chart-release-colors";
 
 export const ChartReleaseLinkChip: React.FunctionComponent<{
   chartRelease: string;
-  chart: string;
-  environment: string;
+  chart?: string;
+  environment?: string;
   arrow?: boolean;
 }> = ({ chartRelease, chart, environment, arrow }) => (
   <LinkChip
-    text={`Chart Release: ${chartRelease}`}
+    text={`Chart Instance: ${chartRelease}`}
     arrow={arrow}
-    to={`/environments/${environment}/chart-releases/${chart}`}
+    to={
+      chart && environment
+        ? `/environments/${environment}/chart-releases/${chart}`
+        : `/r/chart-release/${chartRelease}`
+    }
     {...ChartReleaseColors}
   />
 );
@@ -42,7 +46,7 @@ export const ArgoLinkChip: React.FunctionComponent<{
                 controller?.abort();
               }
             },
-            { signal: controller?.signal }
+            { signal: controller?.signal },
           );
         }}
       >

--- a/app/routes/_layout.review-changesets.tsx
+++ b/app/routes/_layout.review-changesets.tsx
@@ -107,7 +107,6 @@ export async function action({ request }: ActionArgs) {
                 .getAll("sync-changeset")
                 .filter((value): value is string => typeof value === "string")
                 .join(","),
-              "refresh-only": (formData.get("action") === "refresh").toString(),
             },
           },
           "sync your changes",
@@ -232,177 +231,201 @@ export default function Route() {
         <BigActionBox
           title="Review Version Changes"
           returnPath={returnURL}
-          returnText="Go Back Without Applying"
+          returnText={
+            changesets.some((c) => !c.appliedAt)
+              ? "Go Back Without Applying"
+              : "Go Home"
+          }
           submitText={`Apply ${includedCount} Change${
             includedCount == 1 ? "" : "s"
           }`}
           hideButton={includedCount == 0}
           {...returnColors}
         >
-          <p>
-            Applying these changes will immediately update our systems to
-            reflect what the versions of{" "}
-            {changesets.length > 0
-              ? "this chart instance"
-              : `these ${changesets.length} chart instances`}{" "}
-            should be.
-          </p>
-          {filterText && (
-            <p>
-              Note that this button will apply <i>all</i> the below changes, not
-              just the ones visible with your "{filterText}" filter.
-            </p>
-          )}
-          {changesets.length > 1 && (
-            <div className="flex flex-col space-y-1">
-              You can click the checkboxes to choose which changes to apply.
-              <ul>
-                {Array.from(includedChangesets).map(([name, included]) => (
-                  <li key={name}>
-                    <label className="inline-block cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={included}
-                        onChange={() => {
-                          setIncludedChangesets(
-                            (previous) =>
-                              new Map([
-                                ...previous,
-                                [name, !(previous.get(name) || false)],
-                              ]),
-                          );
-                        }}
-                        className="align-middle mr-3 cursor-pointer"
-                      />
-                      <span className="align-middle">{name}</span>
-                    </label>
-                    {included && (
-                      <input
-                        type="hidden"
-                        name="changeset"
-                        value={changesetLookup.get(name)?.id}
-                      />
-                    )}
-                    {included &&
-                      changesetLookup.get(name)?.chartReleaseInfo
-                        ?.environmentInfo?.lifecycle !== "template" && (
-                        <>
-                          {/* 
+          {changesets.some((c) => !c.appliedAt) ? (
+            <>
+              <p>
+                Beehive has planned out these version changes, but they're not
+                applied yet. Click the "
+                <b className="font-semibold">{`Apply ${includedCount} Change${
+                  includedCount == 1 ? "" : "s"
+                }`}</b>
+                " button below to apply these versions.
+              </p>
+              {filterText && (
+                <p>
+                  Note that this button will apply <i>all</i> the below changes,
+                  not just the ones visible with your "{filterText}" filter.
+                </p>
+              )}
+              {changesets.length > 1 && (
+                <div className="flex flex-col space-y-1">
+                  You can click the checkboxes to choose which changes to apply.
+                  <ul>
+                    {Array.from(includedChangesets).map(([name, included]) => (
+                      <li key={name}>
+                        <label className="inline-block cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={included}
+                            onChange={() => {
+                              setIncludedChangesets(
+                                (previous) =>
+                                  new Map([
+                                    ...previous,
+                                    [name, !(previous.get(name) || false)],
+                                  ]),
+                              );
+                            }}
+                            className="align-middle mr-3 cursor-pointer"
+                          />
+                          <span className="align-middle">{name}</span>
+                        </label>
+                        {included && (
+                          <input
+                            type="hidden"
+                            name="changeset"
+                            value={changesetLookup.get(name)?.id}
+                          />
+                        )}
+                        {included &&
+                          changesetLookup.get(name)?.chartReleaseInfo
+                            ?.environmentInfo?.lifecycle !== "template" && (
+                            <>
+                              {/* 
                           These two inputs are basically passed verbatim to the GitHub Action that will sync 
                           or refresh changes. We're indeed potentially passing the changeset ID again, but 
                           it helps the Remix action know what to do. The 'changeset' list from above are the 
                           changesets to apply, while 'sync-changeset' is a similar list but lacking templates
                           so it makes sense to be passed to the sync GHA.
                           */}
-                          <input type="hidden" name="sync" value={name} />
-                          <input
-                            type="hidden"
-                            name="sync-changeset"
-                            value={changesetLookup.get(name)?.id}
-                          />
-                        </>
-                      )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {changesets.length == 1 && (
-            <>
-              <input
-                type="hidden"
-                name="changeset"
-                value={changesets.at(0)?.id}
-              />
-              {changesets.at(0)?.chartReleaseInfo?.environmentInfo
-                ?.lifecycle === "template" || (
+                              <input type="hidden" name="sync" value={name} />
+                              <input
+                                type="hidden"
+                                name="sync-changeset"
+                                value={changesetLookup.get(name)?.id}
+                              />
+                            </>
+                          )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {changesets.length == 1 && (
                 <>
-                  {/*
+                  <input
+                    type="hidden"
+                    name="changeset"
+                    value={changesets.at(0)?.id}
+                  />
+                  {changesets.at(0)?.chartReleaseInfo?.environmentInfo
+                    ?.lifecycle === "template" || (
+                    <>
+                      {/*
                   Same as the above comment here, just in a different form because we're in a different
                   (single change) case where the HTML is structured differently.
                   */}
-                  <input
-                    type="hidden"
-                    name="sync"
-                    value={changesets.at(0)?.chartRelease || ""}
-                  />
-                  <input
-                    type="hidden"
-                    name="sync-changeset"
-                    value={changesets.at(0)?.id}
-                  />
+                      <input
+                        type="hidden"
+                        name="sync"
+                        value={changesets.at(0)?.chartRelease || ""}
+                      />
+                      <input
+                        type="hidden"
+                        name="sync-changeset"
+                        value={changesets.at(0)?.id}
+                      />
+                    </>
+                  )}
                 </>
               )}
+              <details>
+                <summary className="cursor-pointer">
+                  Click here if you'd like to set advanced or non-standard
+                  deployment options.
+                </summary>
+                <EnumInputSelect
+                  name="action"
+                  className="grid grid-cols-2 mt-2"
+                  fieldValue={actionToRun}
+                  setFieldValue={setActionToRun}
+                  enums={[
+                    ["Run Deployment", "sync"],
+                    ["Do Nothing", "none"],
+                  ]}
+                  {...returnColors}
+                />
+                <div className="mt-4 pl-6 border-l-2 border-color-divider-line flex gap-2 flex-col">
+                  {actionToRun === "sync" && (
+                    <>
+                      <p className="font-semibold">
+                        This option is the default.
+                      </p>
+                      <p>
+                        A GitHub Action will be kicked off to deploy any
+                        selected changes as soon as you apply them.
+                      </p>
+                      <p>This means it will hard-refresh and sync ArgoCD.</p>
+                      <p>
+                        When that GitHub Action completes, post-deploy hooks
+                        (like Slack notifications) will run normally.
+                      </p>
+                    </>
+                  )}
+                  {actionToRun === "none" && (
+                    <>
+                      <p>
+                        When you apply version changes, nothing will happen
+                        afterwards.
+                      </p>
+                      <p>
+                        Our platform will remember your changes, but they won't
+                        be deployed until someone/something hard-refreshes and
+                        syncs ArgoCD.
+                      </p>
+                      <p>
+                        Since no automatic deployment action will be run,
+                        post-deploy hooks (like Slack notifications) will not be
+                        run.
+                      </p>
+                      <p className="font-semibold">
+                        This option is not recommended unless you want to use
+                        ArgoCD yourself to manually deploy changes.
+                      </p>
+                    </>
+                  )}
+                  {includesTemplate && (
+                    <p>
+                      At least one of the changes you're applying is to a
+                      template, so no GitHub Action will be run for that
+                      regardless of what option you select here.
+                    </p>
+                  )}
+                </div>
+              </details>
+            </>
+          ) : (
+            <>
+              <p>These changes have already been applied.</p>
+              <p>
+                You can click the buttons in each entry to jump to that resource
+                in Beehive.
+              </p>
             </>
           )}
-          <div>
-            <h2 className="font-light text-2xl">Action to Run</h2>
-            <EnumInputSelect
-              name="action"
-              className="grid grid-cols-3 mt-2"
-              fieldValue={actionToRun}
-              setFieldValue={setActionToRun}
-              enums={[
-                ["Refresh + Sync", "sync"],
-                ["Refresh", "refresh"],
-                ["None", "none"],
-              ]}
-              {...returnColors}
-            />
-            <div className="mt-4 pl-6 border-l-2 border-color-divider-line flex flex-col">
-              {actionToRun === "sync" && (
-                <>
-                  <p className="pb-2">
-                    When applying, a GitHub Action will be kicked off to{" "}
-                    <b className="font-semibold">refresh and sync</b> ArgoCD.
-                    This will deploy the applied versions immediately.
-                  </p>
-                  <p>
-                    Note that refreshing ArgoCD just makes it notice the
-                    versions you're applying here, it won't recalculate
-                    anything.
-                  </p>
-                </>
-              )}
-              {actionToRun === "refresh" && (
-                <>
-                  <p className="pb-2">
-                    When applying, a GitHub Action will be kicked off to{" "}
-                    <b className="font-semibold">just refresh</b> ArgoCD. This
-                    will not deployed the applied versions immediately, but it
-                    will make ArgoCD say that the app is "out of sync." ArgoCD's
-                    manual sync button would then deploy the new versions.
-                  </p>
-                  <p>
-                    Note that refreshing ArgoCD just makes it notice the
-                    versions you're applying here, it won't recalculate
-                    anything.
-                  </p>
-                </>
-              )}
-              {actionToRun === "none" && (
-                <p>
-                  When applying, no GitHub Action will be kicked off. The
-                  changes won't be deployed until someone or something
-                  hard-refreshes and syncs ArgoCD.
-                </p>
-              )}
-              {includesTemplate && (
-                <p className="mt-4">
-                  {
-                    "At least one of the changes you're applying is to a template, so no GitHub Actions will be run for that regardless of what option you select here."
-                  }
-                </p>
-              )}
-            </div>
-          </div>
+
           {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
         </BigActionBox>
       </OutsetPanel>
 
       <InsetPanel size="two-thirds">
         <InteractiveList
-          title="Changes to Be Applied"
+          title={
+            changesets.some((c) => !c.appliedAt)
+              ? "Changes to Be Applied"
+              : "Applied Changes"
+          }
           size="two-thirds"
           {...ChartReleaseColors}
         >


### PR DESCRIPTION
This page means a lot more now that Sherlock links to it. Some UX improvements:

# When looking at already-applied changes:
Before:
![Screenshot 2023-08-18 at 4 06 32 PM](https://github.com/broadinstitute/beehive/assets/29168264/95d7b92d-9aef-468c-b3ad-4839a259d146)
After:
![Screenshot 2023-08-18 at 4 06 17 PM](https://github.com/broadinstitute/beehive/assets/29168264/6ec197ea-41ed-451b-90a8-7f62da4e3dce)

# When about to apply changes:
Before:
![Screenshot 2023-08-18 at 4 25 25 PM](https://github.com/broadinstitute/beehive/assets/29168264/92edd03b-1c6b-41bb-a581-6a12b16d96ce)
After, upon page load:
![Screenshot 2023-08-18 at 4 25 08 PM](https://github.com/broadinstitute/beehive/assets/29168264/c732cb82-ec64-48c5-9638-0b6b8b63735c)
After, if you expand the dropdown:
![Screenshot 2023-08-18 at 4 25 12 PM](https://github.com/broadinstitute/beehive/assets/29168264/93152d90-f743-4656-a86f-b57dd3d0f2fd)

This does remove the refresh-only option from the UI. I don't think people should ever use that now, because it would run deploy hooks without having done the deployment. I think allowing just "run deployment" and "do nothing" as options is sufficient.

## Testing

Ran it! See above 🎉 

## Risk

Pretty low -- I'm not changing the mechanics of this page much, just what text is shown where. My final tests were running it against Sherlock prod, so that's as real as it gets.