### PR TITLE
[DDO-3142] Make helmfileRef overrides optional

### DIFF
--- a/app/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel.tsx
+++ b/app/features/sherlock/chart-releases/change-versions/change-chart-release-versions-panel.tsx
@@ -190,6 +190,11 @@ export const ChangeChartReleaseVersionsPanel: React.FunctionComponent<{
                 initialHelmfileRef={
                   formState?.toHelmfileRef || chartRelease.helmfileRef || "HEAD"
                 }
+                initialHelmfileRefEnabled={String(
+                  formState?.toHelmfileRefEnabled ||
+                    chartRelease.helmfileRefEnabled ||
+                    false,
+                )}
               />
             </>
           )) || (

--- a/app/features/sherlock/chart-versions/set/chart-version-picker.tsx
+++ b/app/features/sherlock/chart-versions/set/chart-version-picker.tsx
@@ -21,6 +21,7 @@ export const ChartVersionPicker: React.FunctionComponent<
     initialChartVersionExact: string;
     initialChartVersionFollowChartRelease: string;
     initialHelmfileRef: string;
+    initialHelmfileRefEnabled: string;
   } & SetsSidebarProps
 > = ({
   setSidebarFilterText,
@@ -32,15 +33,19 @@ export const ChartVersionPicker: React.FunctionComponent<
   initialChartVersionExact,
   initialChartVersionFollowChartRelease,
   initialHelmfileRef,
+  initialHelmfileRefEnabled,
 }) => {
   const [chartVersionResolver, setChartVersionResolver] = useState(
-    initialChartVersionResolver
+    initialChartVersionResolver,
   );
   const [chartVersionExact, setChartVersionExact] = useState(
-    initialChartVersionExact
+    initialChartVersionExact,
   );
   const [chartVersionFollowChartRelease, setChartVersionFollowChartRelease] =
     useState(initialChartVersionFollowChartRelease);
+  const [helmfileRefEnabled, setHelmfileRefEnabled] = useState(
+    initialHelmfileRefEnabled,
+  );
   return (
     <div className="flex flex-col space-y-4">
       <div>
@@ -175,26 +180,47 @@ export const ChartVersionPicker: React.FunctionComponent<
             automatically upon each refresh.
           </p>
         )}
-        <label>
-          <h2 className="font-light text-2xl">Helmfile Ref</h2>
-          <p>
-            This is the Git reference in{" "}
-            <a
-              href="https://github.com/broadinstitute/terra-helmfile"
-              target="_blank"
-              className="underline decoration-color-link-underline"
-            >
-              terra-helmfile
-            </a>{" "}
-            to use for configuration values.
-          </p>
-          <TextField
-            name={isTargetingChangeset ? "toHelmfileRef" : "helmfileRef"}
-            defaultValue={initialHelmfileRef}
-            required
-            placeholder="(required)"
+        <div>
+          <h2 className="font-light text-xl">Custom Helmfile Ref</h2>
+          <EnumInputSelect
+            name={
+              isTargetingChangeset
+                ? "toHelmfileRefEnabled"
+                : "helmfileRefEnabled"
+            }
+            className="grid grid-cols-2 mt-2"
+            fieldValue={helmfileRefEnabled}
+            setFieldValue={setHelmfileRefEnabled}
+            enums={[
+              ["Enabled", "true"],
+              ["Disabled", "false"],
+            ]}
+            {...ChartVersionColors}
           />
-        </label>
+        </div>
+        {helmfileRefEnabled === "true" && (
+          <label>
+            <h2 className="font-light text-xl">Helmfile Ref</h2>
+            <p>
+              This is the Git reference in{" "}
+              <a
+                href="https://github.com/broadinstitute/terra-helmfile"
+                target="_blank"
+                className="underline decoration-color-link-underline"
+              >
+                terra-helmfile
+              </a>{" "}
+              to use for Helm. Set this to the name of your PR branch to test
+              before merging.
+            </p>
+            <TextField
+              name={isTargetingChangeset ? "toHelmfileRef" : "helmfileRef"}
+              defaultValue={initialHelmfileRef}
+              required
+              placeholder="(required)"
+            />
+          </label>
+        )}
       </div>
     </div>
   );

--- a/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.change-versions.tsx
+++ b/app/routes/_layout.charts.$chartName.chart-releases.$chartReleaseName.change-versions.tsx
@@ -62,22 +62,22 @@ export function loader({ request, params }: LoaderArgs) {
             chartReleases.filter(
               (chartRelease) =>
                 chartRelease.cluster !== params.clusterName &&
-                chartRelease.namespace !== params.namespace
-            )
+                chartRelease.namespace !== params.namespace,
+            ),
           ),
-        errorResponseThrower
+        errorResponseThrower,
       )
       .then((chartReleases) => chartReleases.sort(chartReleaseSorter)),
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -92,6 +92,7 @@ export async function action({ request, params }: ActionArgs) {
   const changesetRequest: V2controllersChangesetPlanRequestChartReleaseEntry = {
     ...formDataToObject(formData, true),
     chartRelease: params.chartReleaseName || "",
+    toHelmfileRefEnabled: formData.get("toHelmfileRefEnabled") === "true",
   };
 
   return new ChangesetsApi(SherlockConfiguration)
@@ -101,7 +102,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      handleIAP(request)
+      handleIAP(request),
     )
     .then((changesets) => {
       return changesets.length > 0
@@ -109,9 +110,9 @@ export async function action({ request, params }: ActionArgs) {
             `/review-changesets?${[
               ...changesets.map((c) => `changeset=${c.id}`),
               `return=${encodeURIComponent(
-                `/charts/${params.chartName}/chart-releases/${params.chartReleaseName}`
+                `/charts/${params.chartName}/chart-releases/${params.chartReleaseName}`,
               )}`,
-            ].join("&")}`
+            ].join("&")}`,
           )
         : json({ formState: changesetRequest });
     }, makeErrorResponseReturner(changesetRequest));

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.change-versions.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.$namespace.$chartName.change-versions.tsx
@@ -62,22 +62,22 @@ export function loader({ request, params }: LoaderArgs) {
             chartReleases.filter(
               (chartRelease) =>
                 chartRelease.cluster !== params.clusterName &&
-                chartRelease.namespace !== params.namespace
-            )
+                chartRelease.namespace !== params.namespace,
+            ),
           ),
-        errorResponseThrower
+        errorResponseThrower,
       )
       .then((chartReleases) => chartReleases.sort(chartReleaseSorter)),
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -92,6 +92,7 @@ export async function action({ request, params }: ActionArgs) {
   const changesetRequest: V2controllersChangesetPlanRequestChartReleaseEntry = {
     ...formDataToObject(formData, true),
     chartRelease: `${params.clusterName}/${params.namespace}/${params.chartName}`,
+    toHelmfileRefEnabled: formData.get("toHelmfileRefEnabled") === "true",
   };
 
   return new ChangesetsApi(SherlockConfiguration)
@@ -101,7 +102,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      handleIAP(request)
+      handleIAP(request),
     )
     .then((changesets) => {
       return changesets.length > 0
@@ -109,9 +110,9 @@ export async function action({ request, params }: ActionArgs) {
             `/review-changesets?${[
               ...changesets.map((c) => `changeset=${c.id}`),
               `return=${encodeURIComponent(
-                `/clusters/${params.clusterName}/chart-releases/${params.namespace}/${params.chartName}`
+                `/clusters/${params.clusterName}/chart-releases/${params.namespace}/${params.chartName}`,
               )}`,
-            ].join("&")}`
+            ].join("&")}`,
           )
         : json({ formState: changesetRequest });
     }, makeErrorResponseReturner(changesetRequest));

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
@@ -107,6 +107,7 @@ export async function action({ request, params }: ActionArgs) {
       typeof port === "string" && port !== "" ? parseInt(port) : undefined)(
       formData.get("port"),
     ),
+    helmfileRefEnabled: formData.get("helmfileRefEnabled") === "true",
   };
 
   return new ChartReleasesApi(SherlockConfiguration)

--- a/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.clusters.$clusterName.($filterNamespace).chart-releases.add.$chartName.tsx
@@ -64,7 +64,7 @@ export async function loader({ request, params }: LoaderArgs) {
     new ChartsApi(SherlockConfiguration)
       .apiV2ChartsSelectorGet(
         { selector: params.chartName || "" },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartReleasesApi(SherlockConfiguration)
@@ -75,21 +75,21 @@ export async function loader({ request, params }: LoaderArgs) {
             .filter(
               (chartRelease) =>
                 chartRelease.cluster !== params.clusterName &&
-                chartRelease.namespace !== params.namespace
+                chartRelease.namespace !== params.namespace,
             )
             .sort(chartReleaseSorter),
-        errorResponseThrower
+        errorResponseThrower,
       ),
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
   ]);
@@ -105,14 +105,14 @@ export async function action({ request, params }: ActionArgs) {
     cluster: params.clusterName,
     port: ((port) =>
       typeof port === "string" && port !== "" ? parseInt(port) : undefined)(
-      formData.get("port")
+      formData.get("port"),
     ),
   };
 
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesPost(
       { chartRelease: chartReleaseRequest },
-      handleIAP(request)
+      handleIAP(request),
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {
@@ -124,7 +124,7 @@ export async function action({ request, params }: ActionArgs) {
               "bee-name": chartRelease.environmentInfo?.name || "",
             },
           },
-          "sync your BEE"
+          "sync your BEE",
         );
       }
       return redirect(
@@ -133,7 +133,7 @@ export async function action({ request, params }: ActionArgs) {
           headers: {
             "Set-Cookie": await commitSession(session),
           },
-        }
+        },
       );
     }, makeErrorResponseReturner(chartReleaseRequest));
 }
@@ -216,6 +216,9 @@ export default function Route() {
               errorInfo?.formState?.chartVersionFollowChartRelease || ""
             }
             initialHelmfileRef={errorInfo?.formState?.helmfileRef || "HEAD"}
+            initialHelmfileRefEnabled={String(
+              errorInfo?.formState?.helmfileRefEnabled || false,
+            )}
           />
           <details className="pt-2">
             <summary className="cursor-pointer font-medium">

--- a/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.change-versions.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.$chartName.change-versions.tsx
@@ -63,22 +63,22 @@ export function loader({ request, params }: LoaderArgs) {
             chartReleases
               .filter(
                 (chartRelease) =>
-                  chartRelease.environment !== params.environmentName
+                  chartRelease.environment !== params.environmentName,
               )
-              .sort(chartReleaseSorter)
+              .sort(chartReleaseSorter),
           ),
-        errorResponseThrower
+        errorResponseThrower,
       ),
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     preconfiguredAppVersionExact,
@@ -94,6 +94,7 @@ export async function action({ request, params }: ActionArgs) {
   const changesetRequest: V2controllersChangesetPlanRequestChartReleaseEntry = {
     ...formDataToObject(formData, true),
     chartRelease: `${params.environmentName}/${params.chartName}`,
+    toHelmfileRefEnabled: formData.get("toHelmfileRefEnabled") === "true",
   };
 
   return new ChangesetsApi(SherlockConfiguration)
@@ -103,7 +104,7 @@ export async function action({ request, params }: ActionArgs) {
           chartReleases: [changesetRequest],
         },
       },
-      handleIAP(request)
+      handleIAP(request),
     )
     .then(
       (changesets) =>
@@ -112,12 +113,12 @@ export async function action({ request, params }: ActionArgs) {
               `/review-changesets?${[
                 ...changesets.map((c) => `changeset=${c.id}`),
                 `return=${encodeURIComponent(
-                  `/environments/${params.environmentName}/chart-releases/${params.chartName}`
+                  `/environments/${params.environmentName}/chart-releases/${params.chartName}`,
                 )}`,
-              ].join("&")}`
+              ].join("&")}`,
             )
           : json({ formState: changesetRequest }),
-      makeErrorResponseReturner(changesetRequest)
+      makeErrorResponseReturner(changesetRequest),
     );
 }
 

--- a/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
@@ -105,6 +105,7 @@ export async function action({ request, params }: ActionArgs) {
       typeof port === "string" && port !== "" ? parseInt(port) : undefined)(
       formData.get("port"),
     ),
+    helmfileRefEnabled: formData.get("helmfileRefEnabled") === "true",
   };
 
   return new ChartReleasesApi(SherlockConfiguration)

--- a/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
+++ b/app/routes/_layout.environments.$environmentName.chart-releases.add.$chartName.tsx
@@ -63,7 +63,7 @@ export async function loader({ request, params }: LoaderArgs) {
     new ChartsApi(SherlockConfiguration)
       .apiV2ChartsSelectorGet(
         { selector: params.chartName || "" },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartReleasesApi(SherlockConfiguration)
@@ -73,21 +73,21 @@ export async function loader({ request, params }: LoaderArgs) {
           Array.from(
             chartReleases.filter(
               (chartRelease) =>
-                chartRelease.environment !== params.environmentName
-            )
+                chartRelease.environment !== params.environmentName,
+            ),
           ),
-        errorResponseThrower
+        errorResponseThrower,
       ),
     new AppVersionsApi(SherlockConfiguration)
       .apiV2AppVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
     new ChartVersionsApi(SherlockConfiguration)
       .apiV2ChartVersionsGet(
         { chart: params.chartName, limit: 25 },
-        handleIAP(request)
+        handleIAP(request),
       )
       .catch(errorResponseThrower),
   ]);
@@ -103,14 +103,14 @@ export async function action({ request, params }: ActionArgs) {
     environment: params.environmentName,
     port: ((port) =>
       typeof port === "string" && port !== "" ? parseInt(port) : undefined)(
-      formData.get("port")
+      formData.get("port"),
     ),
   };
 
   return new ChartReleasesApi(SherlockConfiguration)
     .apiV2ChartReleasesPost(
       { chartRelease: chartReleaseRequest },
-      handleIAP(request)
+      handleIAP(request),
     )
     .then(async (chartRelease) => {
       if (chartRelease.environmentInfo?.lifecycle === "dynamic") {
@@ -122,7 +122,7 @@ export async function action({ request, params }: ActionArgs) {
               "bee-name": chartRelease.environmentInfo?.name || "",
             },
           },
-          "sync your BEE"
+          "sync your BEE",
         );
       }
       return redirect(
@@ -131,7 +131,7 @@ export async function action({ request, params }: ActionArgs) {
           headers: {
             "Set-Cookie": await commitSession(session),
           },
-        }
+        },
       );
     }, makeErrorResponseReturner(chartReleaseRequest));
 }
@@ -218,6 +218,9 @@ export default function Route() {
               errorInfo?.formState?.chartVersionFollowChartRelease || ""
             }
             initialHelmfileRef={errorInfo?.formState?.helmfileRef || "HEAD"}
+            initialHelmfileRefEnabled={String(
+              errorInfo?.formState?.helmfileRefEnabled || false,
+            )}
           />
           <details className="pt-2">
             <summary className="cursor-pointer font-medium">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@remix-run/node": "^1.19.3",
         "@remix-run/react": "^1.19.3",
         "@remix-run/serve": "^1.19.3",
-        "@sherlock-js-client/sherlock": "^0.1.134",
+        "@sherlock-js-client/sherlock": "^0.1.138",
         "lucide-react": "^0.276.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "node_modules/@sherlock-js-client/sherlock": {
-      "version": "0.1.134",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.134.tgz",
-      "integrity": "sha512-B70R95DEsRqZET9+peUAJ07ZW+7utTbuYzCvxO1L7oQt4oSGrEOPLfYKPOG+8RztbKIM0vOU9+7Zx/O6pnoxCQ=="
+      "version": "0.1.138",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.138.tgz",
+      "integrity": "sha512-Sg7HQrzxEmehTT8xUcnfbSJdjacR882tR1OjJUMmZaVyLEk0tiDBCNHgchGJzyis7sbQMouem/9kPFnP0yyh+w=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -17483,9 +17483,9 @@
       "dev": true
     },
     "@sherlock-js-client/sherlock": {
-      "version": "0.1.134",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.134.tgz",
-      "integrity": "sha512-B70R95DEsRqZET9+peUAJ07ZW+7utTbuYzCvxO1L7oQt4oSGrEOPLfYKPOG+8RztbKIM0vOU9+7Zx/O6pnoxCQ=="
+      "version": "0.1.138",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.138.tgz",
+      "integrity": "sha512-Sg7HQrzxEmehTT8xUcnfbSJdjacR882tR1OjJUMmZaVyLEk0tiDBCNHgchGJzyis7sbQMouem/9kPFnP0yyh+w=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@remix-run/node": "^1.19.3",
     "@remix-run/react": "^1.19.3",
     "@remix-run/serve": "^1.19.3",
-    "@sherlock-js-client/sherlock": "^0.1.134",
+    "@sherlock-js-client/sherlock": "^0.1.138",
     "lucide-react": "^0.276.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Add Beehive support for https://github.com/broadinstitute/sherlock/pull/295:

This means that we now have an enabled/disabled toggle for setting a custom helmfile ref:
![Screenshot 2023-09-15 at 3 32 18 PM](https://github.com/broadinstitute/beehive/assets/60902147/717eae8e-5e01-4c0d-82c4-b333e7b983a8)

### Testing

I manually tested the following use cases locally:
* Add chart release to environment and cluster (with and without custom helmfile ref)
* Change helmfileRef using "change versions" from environment, cluster, and chart pages
* Monolith promotion does not raise error, or copy helmfileRef settings from another environment
* Monolith promotion *does* change helmfileRef to latest chart release version tag when no custom helmfileRef is set, and Sherlock's `helmfileRefDefaultToChartReleaseTags` config flag is set to true
