### PR TITLE
[DDO-3143] Display Slack info on profile

### DIFF
--- a/app/features/sherlock/users/edit/user-editable-fields.tsx
+++ b/app/features/sherlock/users/edit/user-editable-fields.tsx
@@ -1,22 +1,20 @@
-import { SerializeFrom } from "@remix-run/node";
-import { V2controllersEditableUser } from "@sherlock-js-client/sherlock";
+import type { SerializeFrom } from "@remix-run/node";
+import type { SherlockUserV3Upsert } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
 import { TextField } from "~/components/interactivity/text-field";
 import { UserColors } from "../user-colors";
 
 export const UserEditableFields: React.FunctionComponent<{
-  user?: V2controllersEditableUser | SerializeFrom<V2controllersEditableUser>;
+  user?: SherlockUserV3Upsert | SerializeFrom<SherlockUserV3Upsert>;
 }> = ({ user }) => {
-  const [nameInferredFromGithub, setNameInferredFromGithub] = useState(
-    user?.nameInferredFromGithub != null
-      ? user.nameInferredFromGithub.toString()
-      : "true"
-  );
+  const [nameFrom, setNameFrom] = useState(user?.nameFrom ?? "");
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
-        <h2 className="font-light text-2xl">Get Name From GitHub Profile?</h2>
+        <h2 className="font-light text-2xl">
+          How Should We Determine Your Name?
+        </h2>
         <p>
           Our platform tries to keep track of everyone's names, nicknames, or
           usernames to help identify you to other folks in Beehive.
@@ -26,25 +24,38 @@ export const UserEditableFields: React.FunctionComponent<{
           but it isn't considered sensitive by our systems either, so it could
           potentially get logged.
         </p>
-        <p>
-          By default, our systems will keep your name here consistent with the
-          name on your GitHub profile. You can change that behavior here if
-          you'd like.
-        </p>
         <EnumInputSelect
-          name="nameInferredFromGithub"
-          className="grid grid-cols-2"
-          fieldValue={nameInferredFromGithub}
-          setFieldValue={setNameInferredFromGithub}
-          enums={[
-            ["Yes", "true"],
-            ["No", "false"],
-          ]}
+          name="nameFrom"
+          className={user?.nameFrom ? "grid grid-cols-3" : "grid grid-cols-4"}
+          fieldValue={nameFrom}
+          setFieldValue={setNameFrom}
+          enums={
+            user?.nameFrom
+              ? [
+                  ["From Slack", "slack"],
+                  ["From GitHub", "github"],
+                  ["Custom", "sherlock"],
+                ]
+              : [
+                  ["From Slack", "slack"],
+                  ["From GitHub", "github"],
+                  ["Custom", "sherlock"],
+                  ["(Not Set)", ""],
+                ]
+          }
           {...UserColors}
         />
       </div>
       <div className="pl-6 border-l-2 border-color-divider-line flex flex-col gap-4">
-        {nameInferredFromGithub === "true" ? (
+        {nameFrom === "slack" && (
+          <p>
+            When you save, Beehive will take a second to synchronously re-link
+            your Slack to make sure your name is up to date. It uses the "Full
+            Name" field of your Slack profile, which is regularly updated to
+            track your "Preferred Name" inside Broad Institute Workday.
+          </p>
+        )}
+        {nameFrom === "github" && (
           <p>
             When you save, Beehive will take a second to synchronously re-link
             your GitHub to make sure your name is up to date. You can edit your
@@ -53,24 +64,32 @@ export const UserEditableFields: React.FunctionComponent<{
               className="underline decoration-color-link-underline"
               target="_blank"
               href="https://github.com/settings/profile"
+              rel="noreferrer"
             >
               here
             </a>
             .
           </p>
-        ) : (
+        )}
+        {nameFrom === "sherlock" && (
           <label>
             <h2 className="font-light text-2xl">Name</h2>
             <TextField name="name" defaultValue={user?.name} />
           </label>
         )}
+        {!nameFrom && (
+          <p>
+            With this field unset, Sherlock will set it automatically if it
+            observes a name from either Slack or GitHub.
+          </p>
+        )}
       </div>
       <div className="flex flex-col gap-2">
         <h2 className="font-light text-2xl">Changing Other Information</h2>
         <p>
-          If you'd like to change your GitHub login username, you can do that
-          through GitHub. Once that's done, you can click save here and Beehive
-          will pick up any changes.
+          If you'd like to change your GitHub or Slack username, you can do that
+          through those services. Once that's done, you can click save here and
+          Beehive will pick up any changes.
         </p>
         <p>
           If you'd like to change your Broad Institute email address, that's a

--- a/app/features/sherlock/users/list/match-user.ts
+++ b/app/features/sherlock/users/list/match-user.ts
@@ -12,6 +12,8 @@ export function matchUser(
     user.githubUsername?.toLowerCase()?.includes(matchText) ||
     user.githubID?.toLowerCase()?.includes(matchText) ||
     user.name?.toLowerCase()?.includes(matchText) ||
+    user.slackID?.includes(matchText) ||
+    user.slackUsername?.toLowerCase().includes(matchText) ||
     false
   );
 }

--- a/app/features/sherlock/users/set/sidebar-select-user.tsx
+++ b/app/features/sherlock/users/set/sidebar-select-user.tsx
@@ -2,7 +2,7 @@ import type { SerializeFrom } from "@remix-run/node";
 import type { SherlockUserV3 } from "@sherlock-js-client/sherlock";
 import { SidebarFilterControlledList } from "~/components/panel-structures/sidebar-filter-controlled-list";
 import { ListUserButtonText } from "../list/list-user-button-text";
-import { matchUser } from "../list/matchUser";
+import { matchUser } from "../list/match-user";
 import { UserColors } from "../user-colors";
 
 export const SidebarSelectUser: React.FunctionComponent<{

--- a/app/features/sherlock/users/view/user-details.tsx
+++ b/app/features/sherlock/users/view/user-details.tsx
@@ -107,8 +107,45 @@ export const UserDetails: React.FunctionComponent<{
             ) : (
               <p>
                 GitHub account linking will automatically occur in the
-                background if user signs into Beehive. You can refresh the page
-                to pull the latest info.
+                background if the user signs into Beehive. You can refresh the
+                page to pull the latest info.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {user.slackUsername ? (
+          <>
+            <h2 className="font-light text-2xl">Slack Identity</h2>
+            <h1 className="font-light text-4xl">{user.slackUsername}</h1>
+            <p>
+              This information is sourced directly by Sherlock via its Slack
+              authentication.
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              <div>Username</div>
+              <div className="break-words">
+                <CopyableText>{user.slackUsername}</CopyableText>
+              </div>
+              <div>User ID</div>
+              <div className="break-words">
+                <CopyableText>{user.slackID}</CopyableText>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="font-light text-2xl">No Linked Slack Identity</h2>
+            {isServiceAccount ? (
+              <p>
+                Service accounts won't generally have a linked Slack identity.
+              </p>
+            ) : (
+              <p>
+                Slack identity linking will automatically occur in the
+                background if the user signs into Beehive. You can refresh the
+                page to pull the latest info.
               </p>
             )}
           </>

--- a/app/features/sherlock/users/view/user-details.tsx
+++ b/app/features/sherlock/users/view/user-details.tsx
@@ -2,6 +2,7 @@ import type { SerializeFrom } from "@remix-run/node";
 import type { SherlockUserV3 } from "@sherlock-js-client/sherlock";
 import { AlertTriangle, BadgeCheck } from "lucide-react";
 import { CopyableText } from "~/components/interactivity/copyable-text";
+import { ExternalNavButton } from "~/components/interactivity/external-nav-button";
 import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
 import { MutateControls } from "../../mutate-controls";
 import { UserColors } from "../user-colors";
@@ -10,9 +11,26 @@ export const UserDetails: React.FunctionComponent<{
   user: SherlockUserV3 | SerializeFrom<SherlockUserV3>;
   isServiceAccount?: boolean;
   toEdit?: string;
-}> = ({ user, isServiceAccount, toEdit }) => {
+  slackWorkspaceID?: string;
+}> = ({ user, isServiceAccount, toEdit, slackWorkspaceID }) => {
   return (
     <div className="flex flex-col gap-10">
+      {user.slackID && slackWorkspaceID && (
+        <ExternalNavButton
+          icon={
+            <img
+              src="https://a.slack-edge.com/80588/marketing/img/meta/favicon-32.png"
+              className="h-[1.75rem]"
+              alt="Slack"
+            />
+          }
+          to={`slack://user?team=${slackWorkspaceID}&id=${user.slackID}`}
+          beforeBorderClassName="before:border-[#36C5F0]"
+          target="_blank"
+        >
+          <h2>Slack Message ↗</h2>
+        </ExternalNavButton>
+      )}
       <div className="flex flex-col gap-2">
         <h2 className="font-light text-2xl">Security</h2>
         <div className="flex flex-row gap-2">

--- a/app/helpers/csp.server.ts
+++ b/app/helpers/csp.server.ts
@@ -19,7 +19,7 @@ export function getContentSecurityPolicy(nonce?: string | undefined): string {
     `default-src ${self}; ` +
     `script-src ${scriptSrc}; ` +
     `style-src ${self} 'report-sample'; ` +
-    `img-src ${self} data: https://sonarcloud.io; ` +
+    `img-src ${self} data: https://sonarcloud.io https://a.slack-edge.com; ` +
     `font-src ${self}; ` +
     `connect-src ${connectSrc}; ` +
     `media-src ${self}; ` +

--- a/app/routes/_layout.users.tsx
+++ b/app/routes/_layout.users.tsx
@@ -24,7 +24,7 @@ import {
   handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { ListUserButtonText } from "~/features/sherlock/users/list/list-user-button-text";
-import { matchUser } from "~/features/sherlock/users/list/matchUser";
+import { matchUser } from "~/features/sherlock/users/list/match-user";
 import { makeUserSorter } from "~/features/sherlock/users/list/user-sorter";
 import { UserColors } from "~/features/sherlock/users/user-colors";
 import { UserGeneralDetails } from "~/features/sherlock/users/view/user-general-details";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@remix-run/node": "^1.19.3",
         "@remix-run/react": "^1.19.3",
         "@remix-run/serve": "^1.19.3",
-        "@sherlock-js-client/sherlock": "^0.1.138",
+        "@sherlock-js-client/sherlock": "^0.1.139",
         "lucide-react": "^0.276.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "node_modules/@sherlock-js-client/sherlock": {
-      "version": "0.1.138",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.138.tgz",
-      "integrity": "sha512-Sg7HQrzxEmehTT8xUcnfbSJdjacR882tR1OjJUMmZaVyLEk0tiDBCNHgchGJzyis7sbQMouem/9kPFnP0yyh+w=="
+      "version": "0.1.139",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.139.tgz",
+      "integrity": "sha512-CvpbUM1mvD6cXLLPBKcBCoXyGziZIiqEbRMIDEUhWsoKLx4qv5/xziZ9m3Z/IuDTBvrKYzHo3bzl+xgtV/grjQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -17483,9 +17483,9 @@
       "dev": true
     },
     "@sherlock-js-client/sherlock": {
-      "version": "0.1.138",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.138.tgz",
-      "integrity": "sha512-Sg7HQrzxEmehTT8xUcnfbSJdjacR882tR1OjJUMmZaVyLEk0tiDBCNHgchGJzyis7sbQMouem/9kPFnP0yyh+w=="
+      "version": "0.1.139",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-0.1.139.tgz",
+      "integrity": "sha512-CvpbUM1mvD6cXLLPBKcBCoXyGziZIiqEbRMIDEUhWsoKLx4qv5/xziZ9m3Z/IuDTBvrKYzHo3bzl+xgtV/grjQ=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@remix-run/node": "^1.19.3",
     "@remix-run/react": "^1.19.3",
     "@remix-run/serve": "^1.19.3",
-    "@sherlock-js-client/sherlock": "^0.1.138",
+    "@sherlock-js-client/sherlock": "^0.1.139",
     "lucide-react": "^0.276.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/setup-env.bash
+++ b/setup-env.bash
@@ -6,3 +6,4 @@ vault read -format json secret/suitable/beehive/local/github-oauth |
 echo "COOKIE_SIGNING_SECRET=$(echo $RANDOM | md5sum | head -c 20)" >> .env
 
 echo "PAGERDUTY_APP_ID=P2DQ0G3" >> .env
+echo "SLACK_WORKSPACE_ID=T0CMFS7GX" >> .env


### PR DESCRIPTION
DM button relies on https://github.com/broadinstitute/terra-helmfile/pull/4603
![Screenshot 2023-09-18 at 11 34 36 AM](https://github.com/broadinstitute/beehive/assets/29168264/368b4a25-9da3-41ad-965d-dee42facba78)

And the edit page for your own user:

![Screenshot 2023-09-18 at 10 13 44 AM](https://github.com/broadinstitute/beehive/assets/29168264/de63eead-c4d7-48a7-93b4-c75a0daa1a35)

Shows slackID/slackUsername when available and uses nameFrom instead of the deprecated nameInferredFromGithub.

## Testing

Local testing against real Sherlock (since local Sherlock mocks out the user stuff too much to make this interface work quite right).

## Risk

Super low