### PR TITLE
[DDO-3180] Show datarepo and other apps in the app view

### DIFF
--- a/app/routes/_layout.apps.$chartName._index.tsx
+++ b/app/routes/_layout.apps.$chartName._index.tsx
@@ -1,4 +1,4 @@
-import { LoaderArgs } from "@remix-run/node";
+import type { LoaderArgs } from "@remix-run/node";
 import { useLoaderData, useOutletContext } from "@remix-run/react";
 import {
   AppVersionsApi,

--- a/app/routes/_layout.apps.$chartName.tsx
+++ b/app/routes/_layout.apps.$chartName.tsx
@@ -5,12 +5,14 @@ import {
   V2_MetaFunction,
 } from "@remix-run/node";
 import {
+  Link,
   NavLink,
   Outlet,
   Params,
   useLoaderData,
   useNavigate,
   useOutletContext,
+  useParams,
 } from "@remix-run/react";
 import { ChartReleasesApi } from "@sherlock-js-client/sherlock";
 import { ArrowDown, Clock2 } from "lucide-react";
@@ -52,28 +54,28 @@ export async function loader({ request, params }: LoaderArgs) {
       inDev: chartReleasesApi
         .apiV2ChartReleasesSelectorGet(
           { selector: `dev/${params.chartName}` },
-          forwardedIAP
+          forwardedIAP,
         )
         .catch(() => null),
       inAlpha: chartReleasesApi
         .apiV2ChartReleasesSelectorGet(
           { selector: `alpha/${params.chartName}` },
-          forwardedIAP
+          forwardedIAP,
         )
         .catch(() => null),
       inStaging: chartReleasesApi
         .apiV2ChartReleasesSelectorGet(
           { selector: `staging/${params.chartName}` },
-          forwardedIAP
+          forwardedIAP,
         )
         .catch(() => null),
       inProd: chartReleasesApi
         .apiV2ChartReleasesSelectorGet(
           { selector: `prod/${params.chartName}` },
-          forwardedIAP
+          forwardedIAP,
         )
         .catch(() => null),
-    })
+    }),
   );
 }
 
@@ -120,18 +122,20 @@ export default function Route() {
     (inStaging.appVersionExact !== inProd.appVersionExact ||
       inStaging.chartVersionExact !== inProd.chartVersionExact);
 
+  const params = useParams();
+
   return (
     <>
       <InsetPanel size="one-half">
         <div className="flex flex-col items-center">
           <div
             className={`${panelSizeToInnerClassName(
-              "one-half"
+              "one-half",
             )} flex flex-col gap-4 pb-4 laptop:pb-0 text-color-body-text`}
           >
             <div
               className={`relative ${panelSizeToInnerClassName(
-                "fill"
+                "fill",
               )} bg-color-nearest-bg p-3 pt-4 mb-10 shadow-md rounded-2xl rounded-t-none border-2 border-t-0 ${
                 ChartColors.borderClassName
               } flex flex-row justify-between items-center gap-4`}
@@ -144,6 +148,11 @@ export default function Route() {
                 >
                   <AppPopoverContents chart={chartInfo} />
                 </InlinePopover>
+              )}
+              {!chartInfo && params.chartName && (
+                <span className="text-color-header-text text-5xl font-medium">
+                  {params.chartName}
+                </span>
               )}
               {chartInfo?.appImageGitRepo && (
                 <SonarCloudLinkChip repo={chartInfo.appImageGitRepo} />
@@ -218,6 +227,22 @@ export default function Route() {
               <AppInstanceEntry>
                 <AppInstanceEntryInfo chartRelease={inProd} />
               </AppInstanceEntry>
+            )}
+
+            {!inDev && !(inAlpha || inStaging) && !inProd && (
+              <div className="w-full text-center">
+                This service isn't in any environments this abbreviated
+                deployment view is configured for. View instances of it{" "}
+                <Link
+                  className="underline decoration-color-link-underline"
+                  to={`/charts/${
+                    chartInfo?.name || params.chartName
+                  }/chart-releases`}
+                >
+                  here
+                </Link>
+                .
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
Old rule was "if you're deployed in dev and have a git repo configured for your chart, you'll be on the app view page."

New rule is just "if you have a git repo configured for your chart, you'll be on the app view page."

There's handling for if the app isn't deployed in any environments, there's a link to the chart instance list page which is the closest proxy.

While maybe it'll be confusing for things like Beehive and Sherlock and D2P to be in the list... I actually think them being in the list is better than not, because now we can say "if you want to go to prod to go broad.io/beehive/apps" and people will always get guided to the right place.

![Screenshot 2023-09-28 at 3 52 17 PM](https://github.com/broadinstitute/beehive/assets/29168264/a49eded1-61ff-4608-831c-944bdea78e30)
![Screenshot 2023-09-28 at 3 52 12 PM](https://github.com/broadinstitute/beehive/assets/29168264/bb1261e8-c827-4d44-9740-73b5df16baf3)

Tested locally, risk very low