### PR TITLE
[DDO-3169] Reset labels and other filters in Argo list link

### DIFF
--- a/app/features/sherlock/environments/view/environment-details.tsx
+++ b/app/features/sherlock/environments/view/environment-details.tsx
@@ -136,7 +136,7 @@ export const EnvironmentDetails: React.FunctionComponent<
             </a>
           )}
         <a
-          href={`https://ap-argocd.dsp-devops.broadinstitute.org/applications?namespace=${environment.defaultNamespace}`}
+          href={`https://ap-argocd.dsp-devops.broadinstitute.org/applications?namespace=${environment.defaultNamespace}&showFavorites=false&proj=&sync=&health=&cluster=&labels=`}
           target="_blank"
           className="underline decoration-color-link-underline w-fit"
           rel="noreferrer"


### PR DESCRIPTION
Expands out all the filter parameters so Argo won't try to read them out of the user's last settings.

## Testing

Local -- tiny change, see diff

## Risk

Very low