### PR TITLE
[DDO-3289] Fix typo...

### DIFF
--- a/app/features/sherlock/deploy-hooks/test/deploy-hook-test-panel.tsx
+++ b/app/features/sherlock/deploy-hooks/test/deploy-hook-test-panel.tsx
@@ -35,7 +35,7 @@ export const DeployHookTestPanel: React.FunctionComponent<{
         </h2>
         <p>
           Choose whether the hook should be fully executed or whether Beehive
-          should stop just sort of calling {type}.
+          should stop just short of calling {type}.
         </p>
         <EnumInputSelect<"true" | "false">
           name="execute"


### PR DESCRIPTION
Whoops

```diff
-          should stop just sort of calling {type}.
+          should stop just short of calling {type}.
```