### PR TITLE
DDO-3391 Improve Ux Messaging and Error Message for environment name validation

### DIFF
--- a/app/features/sherlock/environments/new/environment-creatable-fields.tsx
+++ b/app/features/sherlock/environments/new/environment-creatable-fields.tsx
@@ -133,6 +133,10 @@ export const EnvironmentCreatableFields: React.FunctionComponent<
               ? "A unique name will be generated if you leave this blank."
               : ""
           }`}</p>
+          <b>
+            The name should be all lowercase with hyphen separators ie:
+            my-new-environment
+          </b>
           <TextField
             name="name"
             placeholder={
@@ -140,6 +144,7 @@ export const EnvironmentCreatableFields: React.FunctionComponent<
             }
             required={lifecycle !== "dynamic"}
             value={name}
+            title="Name should be lowercase and alphanumeric with hyphen separators"
             pattern="[a-z0-9]([\-a-z0-9]*[a-z0-9])?"
             onChange={(e) => setName(e.currentTarget.value)}
           />


### PR DESCRIPTION
Improves the help text for the user when creating an environment. Also the error message returned when pattern validation fails now includes information about what the regex pattern being checked against for the environment name is expecting.

I have tested this by running a local instance of beehive, and then verifying the new help and error text displays as expected.

This doesn't actually change any application behavior, just provides more detailed messaging to the user.

Here's what the new user message and error text look like

<img width="483" alt="Screenshot 2023-12-20 at 10 35 19 AM" src="https://github.com/broadinstitute/beehive/assets/60187023/d5a72723-69af-45a6-8afe-37c80423e4c1">



I'm using the title field to show the error message on failing to match the pattern based on reccomendation in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) for `HTMLInputElement`

<img width="781" alt="Screenshot 2023-12-20 at 10 45 52 AM" src="https://github.com/broadinstitute/beehive/assets/60187023/eb705b6c-715c-4bda-ac5a-62e16945de58">
