### PR TITLE
[DDO-3470] Fix changeset explanations

### DIFF
--- a/app/features/sherlock/changesets/list/changeset-entry.tsx
+++ b/app/features/sherlock/changesets/list/changeset-entry.tsx
@@ -266,8 +266,9 @@ export const ChangesetEntry: React.FunctionComponent<{
                   </ul>
                 )}
                 {appVersionChanged &&
-                  changeset.newAppVersions?.at(0)?.parentAppVersion !==
-                    changeset.fromAppVersionReference && (
+                  changeset.newAppVersions &&
+                  changeset.newAppVersions[changeset.newAppVersions.length - 1]
+                    ?.appVersion != changeset.toAppVersionExact && (
                     <p>
                       A full version tree wasn't built; this list of changes
                       might be incomplete.
@@ -425,8 +426,9 @@ export const ChangesetEntry: React.FunctionComponent<{
               </ul>
             )}
             {chartVersionChanged &&
-              changeset.newChartVersions?.at(0)?.parentChartVersion !==
-                changeset.fromChartVersionReference && (
+              changeset.newChartVersions &&
+              changeset.newChartVersions[changeset.newChartVersions.length - 1]
+                ?.chartVersion != changeset.toChartVersionExact && (
                 <p>
                   A full version tree wasn't built; this list of changes might
                   be incomplete.


### PR DESCRIPTION
Turns out this is fallout from https://github.com/broadinstitute/sherlock/pull/478 -- the detection of when a changelog was complete was mis-ordered.

This doesn't cross my threshold of being a big deal -- the changelog is still shown, just with a warning that other changes might be included.

## Testing

Fixes the issue locally

## Risk

Very low