### PR TITLE
[DDO-3557] Repo Standards Implementation MVP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @broadinstitute/dsp-devops

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+> ### The bottom line is to reach out to DevOps in [#dsp-devops-discussions](https://broadinstitute.enterprise.slack.com/archives/C029LTN5L80) before contributing.
+>
+> This is a small project with a very short list of contributors and it's not as easy to contribute to as many other codebases.
+
+If you'd like to add a theme, additional documentation is available in [`./app/themes`](./app/themes/README.md).
+
+## Running Locally
+
+There's instructions for getting set up in [`README.md`](./README.md).
+
+If you'd like to run against a local Sherlock:
+
+```bash
+npm run dev
+```
+
+If you'd like to run against Sherlock's dev instance, you can use Thelma:
+
+```bash
+IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock-dev.dsp-devops.broadinstitute.org' npm run dev
+```
+
+If you'd like to run against Sherlock's production instance, you can use Thelma here too:
+
+```bash
+IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock.dsp-devops.broadinstitute.org' npm run dev
+```
+
+## Testing
+
+All testing here is manual. It's not ideal but it's the reality of how this codebase was delivered on time: so far, this approach has helped velocity here, not hurt it. [`DESIGN.md`](./DESIGN.md) has more information on some of the choices made to lower the blast radius of changes and make this work.
+
+> If you're feeling like there's something in the UI you can't confidently test manually, in the past that's meant that the functionality needed to be moved to Sherlock.
+
+## Submitting Changes
+
+PRs require a ticket in the title with CLIA risk and security impact description filled. The description must include a summary of the changes, an explanation of what testing was done (screenshots recommended), and a note on the risk of the change.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,49 @@
+# Design
+
+The guiding principle of Beehive is that it's a UI for [Sherlock](https://github.com/broadinstitute/sherlock). **It's part of the DevOps platform, _not_ part of Terra.**
+
+Sherlock is thoroughly tested and carefully designed. To be blunt, the standards here are lower. UI work isn't our team's specialty, so a lot of Beehive's design is about Beehive _not_ doing things. Some examples:
+
+-   Beehive doesn't include any significant business logic: if we care about the behavior, we write it in Sherlock
+-   Beehive doesn't handle authentication or authorization: it runs behind Identity Aware Proxy and passes that through to Sherlock
+-   Beehive doesn't define models or many types at all: we rely on Sherlock's TypeScript client library
+-   Beehive doesn't manage state, routing, or data loading: we use Remix
+-   Beehive doesn't have custom CSS wherever possible: we use Tailwind
+
+## Architecture
+
+The DevOps platform is currently being re-architected for improved security. The existing architecture diagram is [here](https://lucid.app/lucidchart/0b274518-4e5a-449e-b3bc-19714096d5a4/edit?viewport_loc=-2982%2C57%2C5242%2C2868%2C0_0&invitationId=inv_e6f26c4c-902a-4335-b9b8-cc8d4363e66f).
+
+The summary is that Beehive and Sherlock run in the same clusters, with their respective ingresses configured with the same Identity Aware Proxy. Beehive passes requests to Sherlock post-IAP _inside the cluster_. Sherlock handles authentication and authorization.
+
+Beehive truly runs inside the cluster: Remix integrates both backend and frontend. [Remix's docs have more info.](https://remix.run/docs/en/main/discussion/introduction)
+
+## Repository Layout
+
+-   `./app/assets`: Static assets for Remix to bundle and cache-bust
+-   `./app/components`: General-purpose reusable components matching Beehive's styling
+-   `./app/errors`: Error handling components and helpers
+-   `./app/features`: Components and helpers for specific features, e.g. `./app/features/sherlock/environments` for Sherlock environments
+-   `./app/helpers`: Helper functions, primarily for use server-side
+-   `./app/hooks`: Custom React hooks
+-   `./app/routes`: One file for each page Beehive serves
+-   `./app/styles`: CSS for Remix to handle with PostCSS and cache-bust
+-   `./app/themes`: theme-specific CSS for Remix to bundle and cache-bust
+
+`./app` itself contains execution entrypoints for both client and server, but it's `root.tsx` generally makes more sense as the starting point for the application.
+
+## Stack
+
+-   TypeScript: Remix has good support for it and we inherit from Sherlock's types
+-   NPM: We don't need complexity offered by anything else
+-   React: Standard in DSP
+    -   TSX Syntax: All available documentation for other parts of the stack all used TSX (and it's become more standard in DSP since)
+-   [Remix](https://remix.run/): Framework pairing perfectly [with Sherlock](https://remix.run/docs/en/main/guides/bff) and [its hierarchical model structure](https://remix.run/docs/en/main/start/tutorial#nested-routes-and-outlets)
+-   [Tailwind](https://tailwindcss.com/): Good-enough styling and flexibility coupled with excellent documentation for a team that isn't concerned with CSS
+-   [Lucide](https://lucide.dev/): Good-enough collection of tons of icons coupled with excellent documentation for a team that isn't concerned with graphic design
+
+## Themes
+
+Themes aren't just a vanity feature, they're actually a core part of how Beehive helps folks avoid accidental modifications to production -- the theme will flip from light mode to dark mode or vice-versa when moving into a part of the app that directly impacts production.
+
+There's more information available in [`./app/themes`](./app/themes/README.md).

--- a/README.md
+++ b/README.md
@@ -16,24 +16,6 @@ You can use `./scripts/run` or `npm run dev` to run Beehive, the former just cal
 
 You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. You may want to dump a copy of Sherlock's database into your local one to have some data to play with.
 
-Below there's some notes on some Visual Studio Code plugins that are really helpful to install.
-
-> **Note**
->
-> If you don't want to run a local Sherlock but you have a copy of Thelma, you can run Beehive against Sherlock's dev instance like this:
->
-> ```bash
-> IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock-dev.dsp-devops.broadinstitute.org' npm run dev
-> ```
-
-> **Warning**
->
-> If you want to do the above but against Sherlock's prod instance (careful!):
->
-> ```bash
-> IAP_TOKEN="$(thelma auth iap --echo)" SHERLOCK_BASE_URL='https://sherlock.dsp-devops.broadinstitute.org' npm run dev
-> ```
-
 ### If you're using Visual Studio Code
 
 [The Tailwind plugin](vscode:extension/bradlc.vscode-tailwindcss) adds very helpful autocomplete for Tailwind's class names. **This plugin is strongly recommended.**
@@ -42,79 +24,8 @@ Below there's some notes on some Visual Studio Code plugins that are really help
 
 PostCSS also has a plugin but it isn't recommended here as it unnecessarily relaxes a bunch of CSS syntax rules and ends up causing build-time syntax errors. Instead, we just ignore unknown directives in non-Tailwind CSS linting--so far that's caused far fewer errors.
 
-## Stack
+## Further Reading
 
-<details>
-<summary>
-TypeScript
-</summary>
+See [`./DESIGN.md/](./DESIGN.md) for information on how Beehive is built.
 
-We're just building a UI here--we already have a backend that does the business logic, [Sherlock](https://github.com/broadinstitute/sherlock).
-
-We're using TypeScript over JavaScript for many of the same reasons [Terra UI](https://github.com/DataBiosphere/terra-ui) has [considered](https://docs.google.com/document/d/1tX1tGULDnWnWOCzez5WWTSXJFCHxB98rrU07B5u8KNk/edit#heading=h.shrc0akkyq24). In our case, we're starting fresh and the other tooling in this stack has [really good support for it](https://remix.run/docs/en/v1/guides/typescript), so we have fewer downsides to using it.
-
-</details>
-
-<details>
-<summary>
-NPM
-</summary>
-
-We're using NPM over Yarn because NPM is the default and we don't currently have a need to Yarn's extra complexity--we can always move to it later.
-
-</details>
-
-<details>
-<summary>
-React
-</summary>
-
-We're using React because DSP already uses it for [Terra UI](https://github.com/DataBiosphere/terra-ui) and [DUOS UI](https://github.com/DataBiosphere/duos-ui), and we have similar requirements for interactivity--no need to reinvent the wheel.
-
-We use the `tsx` syntax since that's the most common syntax in modern resources online. Files that specifically don't include any inlined React at all can opt to use `ts` to help make that clear. This dovetails nicely with code-splitting hinting to Remix's compiler, resulting in `session.server.ts` vs `clusters.tsx`.
-
-</details>
-
-<details>
-<summary>
-Remix
-</summary>
-
-[Remix](https://remix.run/) is a data loading and rendering framework for React. There's two older, larger competitors, [Gatsby](https://www.gatsbyjs.com/) (which I've used) and [Next](https://nextjs.org/), but they both have gigantic feature sets far beyond what we need. Remix positions itself as a thin layer that just does your site's data loading and rendering [from the server](https://remix.run/docs/en/v1/guides/data-loading), making it super easy to [bring your own actual backend](https://remix.run/docs/en/v1/guides/bff)--exactly what we're doing with [Sherlock](https://github.com/broadinstitute/sherlock).
-
-Another point in favor of Remix over Next is that Remix is essentially [React Router](https://reactrouter.com/en/main) (it's made by the same people) except it loads your data too. This makes a ton of sense for Sherlock specifically because Sherlock's data model is very hierarchical, so hierarchical routes and data-loading from Remix make for very idiomatic source code. [Next plans to add similar functionality in the future](https://nextjs.org/blog/layouts-rfc), but we're building Beehive now, and Remix offers this now.
-
-(We're glossing over a lot here, but the bottom line is that we'll probably use 90%+ of Remix versus maybe 25% of its competitors, and the competitors have more lock-in. Remix saves us from reinventing wheels that we already have from Sherlock or [Identity-Aware Proxy](https://docs.google.com/document/d/1FCVPfCjJMF_ljBTeG6bJwbMUCe52kSsbKWTXCqdO7Nw/edit#heading=h.f25rkrrigwm) while still letting us write, well, React.)
-
-</details>
-
-<details>
-<summary>
-Tailwind
-</summary>
-
-[Tailwind](https://tailwindcss.com/) is a library of utility CSS classes. They have an explanation of why this is [a good idea](https://tailwindcss.com/docs/utility-first) but they're too humble to brag about one of their greatest features: [a documentation site so thorough](https://tailwindcss.com/docs/editor-setup) that we don't all need to memorize CSS or have a thousand tabs open to be able to contribute code to Beehive.
-
-We use Tailwind as a PostCSS plugin along with a few others to help organize files ([import](https://github.com/postcss/postcss-import) and [import-glob](https://github.com/dimitrinicolas/postcss-import-ext-glob)), improve compatibility ([autoprefixer](https://github.com/postcss/autoprefixer)), and lower load times ([cssnano](https://cssnano.co/)); see [postcss.config.js](./postcss.config.js) for more info. Everything in `./styles` ends up in `./app/styles` where [Remix can grab it](https://github.com/dimitrinicolas/postcss-import-ext-glob#example), but working directly with CSS in Beehive is mostly just an escape hatch for when Tailwind can't do something.
-
-</details>
-
-The overall architecture of the system is diagrammed [here](https://lucid.app/lucidchart/0b274518-4e5a-449e-b3bc-19714096d5a4/edit?page=0_0#).
-
-## Documentation
-
-[Remix docs](https://remix.run/docs), [Tailwind docs](https://tailwindcss.com/docs/editor-setup)
-
-### Themes and Colors
-
-Beehive has a theming system. This isn't just a vanity feature, it is used to vary the entire UI when affecting production resources to help avoid accidents.
-
-To support this, use the colors defined in [our Tailwind configuration](./tailwind.config.js) (e.g. use `bg-color-near-bg` instead of `bg-white`).
-
-If you want to add a new theme, see [./app/themes](./app/themes).
-
-### Icons
-
-[Lucide](https://lucide.dev/) is set up, [here's how to use it](https://lucide.dev/docs/lucide-react#how-to-use). You can apply Tailwind classes to the imported components like normal to style them.
-
-(If you know [Feather Icons](https://github.com/feathericons/feather), Lucide is a fork of that project with more active leadership and more icons)
+See [`./CONTRIBUTING.md`](./CONTRIBUTING.md) for information on how to contribute to Beehive (including contributing themes).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 3. Run `./scripts/setup`
 
-You can use `./scripts/run` or `npm run start` to run Beehive, the former just calls the latter.
+You can use `./scripts/run` or `npm run dev` to run Beehive, the former just calls the latter.
 
 You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. You may want to dump a copy of Sherlock's database into your local one to have some data to play with.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 
 2. Clone this repo
 
-3. Run `./setup-env.bash` to pull down the info needed to do local GitHub auth
+3. Run `./scripts/setup`
 
-4. Run `npm install` to download dependencies and `npm run dev` to spin up the development server
+You can use `./scripts/run` or `npm run start` to run Beehive, the former just calls the latter.
 
 You'll probably want a local instance of Sherlock running -- `make local-up` from inside Sherlock's repo will get you set up. You may want to dump a copy of Sherlock's database into your local one to have some data to play with.
+
+Below there's some notes on some Visual Studio Code plugins that are really helpful to install.
 
 > **Note**
 >

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+npm run build

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+npm run start

--- a/scripts/run
+++ b/scripts/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-npm run start
+npm run dev

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
+npm install
 
 gcloud secrets versions access latest --project dsp-tools-k8s --secret beehive-github-oauth-local |
   jq -r  'to_entries[] | "GITHUB_\(.key | ascii_upcase)=\(.value)"' > .env
 
-# Pact credentials & configurations
 echo "PACT_PASSWORD=$(vault read -format json 'secret/dsp/pact-broker/users/readwrite' | jq -r .data.basic_auth_password)" >> .env
 echo "PACT_USERNAME=$(vault read -format json 'secret/dsp/pact-broker/users/readwrite' | jq -r .data.basic_auth_username)" >> .env
 echo "PACT_BASE_URL=https://pact-broker.dsp-eng-tools.broadinstitute.org" >> .env


### PR DESCRIPTION
An MVP implementation of the [GitHub Repo Standards](https://broadworkbench.atlassian.net/wiki/spaces/TLR/pages/2952298505/GitHub+Repo+Standards#build) doc, taking a more minimal approach than some other repos due to the small scale and contributor list of this project.

- Modifies README.md
- Adds CONTRIBUTING.md
- Adds DESIGN.md
- Adds .editorconfig
- Adds .github/CODEOWNERS
- Adds ./scripts/run
- Adds ./scripts/build
- Moves and modifies setup-env.bash to ./scripts/setup