### PR TITLE
[DDO-3609] Parse mentionPeople to bool

### DIFF
--- a/app/features/sherlock/deploy-hooks/new/new-deploy-hook-action.server.ts
+++ b/app/features/sherlock/deploy-hooks/new/new-deploy-hook-action.server.ts
@@ -38,6 +38,7 @@ export async function newDeployHookAction(
     const slackDeployHookRequest: SherlockSlackDeployHookV3Create = {
       ...formDataToObject(formData, true),
       ...partialTriggerConfig,
+      mentionPeople: formData.get("mentionPeople") === "true",
       onSuccess: formData.get("onSuccess") === "true",
       onFailure: formData.get("onFailure") === "true",
     };


### PR DESCRIPTION
The parse is done for edits but not for new ones. This does imply that no one has tried to create a new slack deploy hook since the advent of Beehive's new notifications... but I'm just going to take that as "I made good selections myself originally and no one's felt the need to add notifs for additional channels"

## Testing

Manual, replicated Olivia's issue and fixed it. This is sorta the roughest edge of Remix, it is what it is

## Risk

Very low, can't be more broken than it is now