### PR TITLE
[DDO-3670] Breakglass role assignments UI

### DIFF
--- a/app/features/sherlock/role-assignments/delete/role-assignment-delete-description.tsx
+++ b/app/features/sherlock/role-assignments/delete/role-assignment-delete-description.tsx
@@ -4,6 +4,7 @@ import type {
   SherlockRoleV3,
   SherlockUserV3,
 } from "@sherlock-js-client/sherlock";
+import { isRoleAssignmentExpired } from "../list/is-expired-or-suspended";
 
 export interface RoleAssignmentDeleteDescriptionProps {
   role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>;
@@ -21,23 +22,29 @@ export const RoleAssignmentDeleteDescription: React.FunctionComponent<
       Are you sure you want to delete this role assignment?
     </h2>
     <p>
-      This will delete the {assignment.suspended ? "suspended" : "active"}{" "}
-      {role.name} role assignment for {user.email}.
+      This will delete the{" "}
+      {assignment.suspended
+        ? "suspended"
+        : isRoleAssignmentExpired(assignment)
+          ? "expired"
+          : "active"}{" "}
+      {role.name} role assignment for{" "}
+      <span className="font-medium">{user.email}</span>.
     </p>
     {(role.grantsDevAzureGroup || role.grantsDevFirecloudGroup) && (
       <p>
-        User will be removed from{` `}
+        User will be removed from
         {role.grantsDevAzureGroup && (
           <span>
-            the {role.grantsDevAzureGroup} Azure group{` `}
+            {` `}the {role.grantsDevAzureGroup} Azure group
           </span>
         )}
         {role.grantsDevAzureGroup && role.grantsDevFirecloudGroup && (
-          <span>and{` `}</span>
+          <span>{` `}and</span>
         )}
         {role.grantsDevFirecloudGroup && (
           <span>
-            the {role.grantsDevFirecloudGroup} firecloud.org Google group{` `}
+            {` `}the {role.grantsDevFirecloudGroup} firecloud.org Google group
           </span>
         )}
         .

--- a/app/features/sherlock/role-assignments/delete/role-assignment-delete-description.tsx
+++ b/app/features/sherlock/role-assignments/delete/role-assignment-delete-description.tsx
@@ -1,0 +1,50 @@
+import type { SerializeFrom } from "@remix-run/node";
+import type {
+  SherlockRoleAssignmentV3,
+  SherlockRoleV3,
+  SherlockUserV3,
+} from "@sherlock-js-client/sherlock";
+
+export interface RoleAssignmentDeleteDescriptionProps {
+  role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>;
+  user: SherlockUserV3 | SerializeFrom<SherlockUserV3>;
+  assignment:
+    | SherlockRoleAssignmentV3
+    | SerializeFrom<SherlockRoleAssignmentV3>;
+}
+
+export const RoleAssignmentDeleteDescription: React.FunctionComponent<
+  RoleAssignmentDeleteDescriptionProps
+> = ({ role, user, assignment }) => (
+  <div className="flex flex-col space-y-4">
+    <h2 className="text-2xl font-light">
+      Are you sure you want to delete this role assignment?
+    </h2>
+    <p>
+      This will delete the {assignment.suspended ? "suspended" : "active"}{" "}
+      {role.name} role assignment for {user.email}.
+    </p>
+    {(role.grantsDevAzureGroup || role.grantsDevFirecloudGroup) && (
+      <p>
+        User will be removed from{` `}
+        {role.grantsDevAzureGroup && (
+          <span>
+            the {role.grantsDevAzureGroup} Azure group{` `}
+          </span>
+        )}
+        {role.grantsDevAzureGroup && role.grantsDevFirecloudGroup && (
+          <span>and{` `}</span>
+        )}
+        {role.grantsDevFirecloudGroup && (
+          <span>
+            the {role.grantsDevFirecloudGroup} firecloud.org Google group{` `}
+          </span>
+        )}
+        .
+      </p>
+    )}
+    {role.grantsSherlockSuperAdmin && (
+      <p>User will lose Sherock Super Admin privileges.</p>
+    )}
+  </div>
+);

--- a/app/features/sherlock/role-assignments/edit/role-assignment-editable-fields.tsx
+++ b/app/features/sherlock/role-assignments/edit/role-assignment-editable-fields.tsx
@@ -1,0 +1,106 @@
+import type { SerializeFrom } from "@remix-run/node";
+import type {
+  SherlockRoleAssignmentV3,
+  SherlockRoleV3,
+} from "@sherlock-js-client/sherlock";
+import { useState } from "react";
+import { EnumInputSelect } from "~/components/interactivity/enum-select";
+import { TextField } from "~/components/interactivity/text-field";
+import { RoleColors } from "../../roles/role-colors";
+
+export interface RoleAssignmentEditableFieldsProps {
+  role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>;
+  assignment:
+    | SherlockRoleAssignmentV3
+    | SerializeFrom<SherlockRoleAssignmentV3>;
+  selfUserIsSuperAdmin: boolean;
+}
+
+export const roleAssignmentEditableFormDataToObject = function (
+  formData: FormData,
+): SherlockRoleAssignmentV3 {
+  return {
+    suspended: formData.get("suspended") === "true",
+    expiresIn:
+      formData.get("expires") === "true"
+        ? formData.get("expiresIn")?.toString()
+        : undefined,
+  };
+};
+
+export const RoleAssignmentEditableFields: React.FunctionComponent<
+  RoleAssignmentEditableFieldsProps
+> = ({ role, assignment, selfUserIsSuperAdmin }) => {
+  const [roleAssignmentSuspended, setRoleAssignmentSuspended] = useState(
+    assignment.suspended ? "true" : "false",
+  );
+
+  const [roleAssignmentExpires, setRoleAssignmentExpires] = useState(
+    assignment.expiresIn ? "true" : "false",
+  );
+
+  const [roleAssignmentExpiresIn, setRoleAssignmentExpiresIn] = useState(
+    assignment.expiresIn || role.defaultGlassBreakDuration || "",
+  );
+
+  return (
+    <div className="flex flex-col space-y-4">
+      {selfUserIsSuperAdmin && (
+        <div>
+          <h2 className="font-light text-2xl text-color-header-text">
+            Suspended
+          </h2>
+          <p>Configure whether the assigment is suspended.</p>
+          <EnumInputSelect
+            name="suspended"
+            className="grid grid-cols-2 mt-2"
+            fieldValue={roleAssignmentSuspended}
+            setFieldValue={setRoleAssignmentSuspended}
+            enums={[
+              ["Yes", "true"],
+              ["No", "false"],
+            ]}
+            {...RoleColors}
+          />
+        </div>
+      )}
+      {selfUserIsSuperAdmin && (
+        <div>
+          <h2 className="font-light text-2xl text-color-header-text">Expiry</h2>
+          <p>Expire role assignment after a period of time.</p>
+          <EnumInputSelect
+            name="expires"
+            className="grid grid-cols-2 mt-2"
+            fieldValue={roleAssignmentExpires}
+            setFieldValue={setRoleAssignmentExpires}
+            enums={[
+              ["Yes", "true"],
+              ["No", "false"],
+            ]}
+            {...RoleColors}
+          />
+        </div>
+      )}
+      {roleAssignmentExpires === "true" && (
+        <label>
+          <h2 className="font-light text-2xl text-color-header-text">
+            Duration
+          </h2>
+          <p>
+            Configure a time period after which this role assignment will
+            expire.
+          </p>
+          <TextField
+            name="expiresIn"
+            value={roleAssignmentExpiresIn}
+            placeholder="eg. 8h0m"
+            required={roleAssignmentExpires === "true"}
+            onChange={(e) => {
+              setRoleAssignmentExpiresIn(e.currentTarget.value);
+            }}
+          />
+        </label>
+      )}
+    </div>
+  );
+};

--- a/app/features/sherlock/role-assignments/list/list-role-assignment-user-button-text.tsx
+++ b/app/features/sherlock/role-assignments/list/list-role-assignment-user-button-text.tsx
@@ -1,0 +1,17 @@
+import type { SerializeFrom } from "@remix-run/node";
+import type {
+  SherlockRoleAssignmentV3,
+  SherlockUserV3,
+} from "@sherlock-js-client/sherlock";
+
+export const ListRoleAssignmentUserButtonText: React.FunctionComponent<{
+  roleAssn: SerializeFrom<SherlockRoleAssignmentV3>;
+}> = ({ roleAssn }) => {
+  const userInfo = roleAssn.userInfo as SherlockUserV3;
+
+  return (
+    <h2 className="font-light">
+      <span className="font-medium">{userInfo.email}</span>
+    </h2>
+  );
+};

--- a/app/features/sherlock/role-assignments/list/match-role-assignment-by-user.ts
+++ b/app/features/sherlock/role-assignments/list/match-role-assignment-by-user.ts
@@ -1,0 +1,17 @@
+import type { SerializeFrom } from "@remix-run/node";
+import {
+  SherlockRoleAssignmentV3,
+  SherlockUserV3,
+} from "@sherlock-js-client/sherlock";
+
+export function matchRoleAssignmentByUser(
+  roleAssignment: SerializeFrom<SherlockRoleAssignmentV3>,
+  matchText: string,
+): boolean {
+  const userInfo = roleAssignment.userInfo as SherlockUserV3;
+  return (
+    userInfo.name?.includes(matchText) ||
+    userInfo.email?.includes(matchText) ||
+    false
+  );
+}

--- a/app/features/sherlock/role-assignments/list/role-assignment-sorter.ts
+++ b/app/features/sherlock/role-assignments/list/role-assignment-sorter.ts
@@ -1,0 +1,51 @@
+import { SerializeFrom } from "@remix-run/node";
+import type {
+  SherlockRoleAssignmentV3,
+  SherlockUserV3,
+} from "@sherlock-js-client/sherlock";
+import { makeUserSorter } from "../../users/list/user-sorter";
+
+export function makeRoleAssignmentSorterForUser(
+  emailToComeFirst?: string | null,
+): (
+  a: SherlockRoleAssignmentV3 | SerializeFrom<SherlockRoleAssignmentV3>,
+  b: SherlockRoleAssignmentV3 | SerializeFrom<SherlockRoleAssignmentV3>,
+) => number {
+  return (a, b) => {
+    const userSorter = makeUserSorter(emailToComeFirst);
+
+    const au = a.userInfo as SherlockUserV3;
+    const bu = b.userInfo as SherlockUserV3;
+
+    // show permanent assignments first, sorted by user email
+    if (a.expiresAt === undefined && b.expiresAt === undefined) {
+      return userSorter(au, bu);
+    }
+    if (a.expiresAt !== undefined && b.expiresAt === undefined) {
+      return -1;
+    }
+    if (a.expiresAt === undefined && b.expiresAt !== undefined) {
+      return 1;
+    }
+
+    // show current user's break glass assignments first
+    if (au.email === emailToComeFirst) {
+      return -1;
+    }
+    if (bu.email === emailToComeFirst) {
+      return 1;
+    }
+
+    // show all other break glass assignments, sorted by expiry
+    if (a.expiresAt! < b.expiresAt!) {
+      return -1;
+    }
+    if (a.expiresAt! > b.expiresAt!) {
+      return 1;
+    }
+
+    // this will never happen (two break glasses that expire at the same time?)
+    // but if it does, sort by user email
+    return userSorter(au, bu);
+  };
+}

--- a/app/features/sherlock/role-assignments/new/role-assignment-creatable-fields.tsx
+++ b/app/features/sherlock/role-assignments/new/role-assignment-creatable-fields.tsx
@@ -28,29 +28,36 @@ export const RoleAssignmentCreatableFields: React.FunctionComponent<
     <div className="flex flex-col space-y-4">
       <label>
         <h2 className="font-light text-2xl text-color-header-text">User</h2>
-        <TextField
-          name="user"
-          disabled={!selfUserIsSuperAdmin}
-          placeholder="Search..."
-          value={user || ""}
-          onChange={(e) => {
-            setUser(e.currentTarget.value);
-            setSidebarFilterText(e.currentTarget.value);
-          }}
-          onFocus={() => {
-            setSidebar(({ filterText }) => (
-              <SidebarSelectUser
-                users={users}
-                fieldValue={filterText}
-                selfEmail={selfUserEmail || ""}
-                setFieldValue={(value) => {
-                  setUser(value);
-                  setSidebar();
-                }}
-              />
-            ));
-          }}
-        />
+        {selfUserIsSuperAdmin ? (
+          <TextField
+            name="user"
+            disabled={!selfUserIsSuperAdmin}
+            placeholder="Search..."
+            value={user || ""}
+            onChange={(e) => {
+              setUser(e.currentTarget.value);
+              setSidebarFilterText(e.currentTarget.value);
+            }}
+            onFocus={() => {
+              setSidebar(({ filterText }) => (
+                <SidebarSelectUser
+                  users={users}
+                  fieldValue={filterText}
+                  selfEmail={selfUserEmail || ""}
+                  setFieldValue={(value) => {
+                    setUser(value);
+                    setSidebar();
+                  }}
+                />
+              ));
+            }}
+          />
+        ) : (
+          <>
+            <span className="pt-2 text-lg">{selfUserEmail}</span>
+            <input name="user" type="hidden" value={selfUserEmail} />
+          </>
+        )}
       </label>
     </div>
   );

--- a/app/features/sherlock/role-assignments/new/role-assignment-creatable-fields.tsx
+++ b/app/features/sherlock/role-assignments/new/role-assignment-creatable-fields.tsx
@@ -1,0 +1,57 @@
+import type { SerializeFrom } from "@remix-run/node";
+import type { SherlockUserV3 } from "@sherlock-js-client/sherlock";
+import { TextField } from "~/components/interactivity/text-field";
+import { SetsSidebarProps } from "~/hooks/use-sidebar";
+import { SidebarSelectUser } from "../../users/set/sidebar-select-user";
+
+export interface RoleAssignmentCreatableFieldsProps {
+  user: string | undefined;
+  setUser: React.Dispatch<React.SetStateAction<string | undefined>>;
+  users: SerializeFrom<Array<SherlockUserV3>>;
+  selfUserEmail?: string;
+  selfUserIsSuperAdmin: boolean;
+}
+
+export const RoleAssignmentCreatableFields: React.FunctionComponent<
+  RoleAssignmentCreatableFieldsProps & SetsSidebarProps
+> = ({
+  user,
+  setUser,
+  users,
+  selfUserEmail,
+  selfUserIsSuperAdmin,
+
+  setSidebarFilterText,
+  setSidebar,
+}) => {
+  return (
+    <div className="flex flex-col space-y-4">
+      <label>
+        <h2 className="font-light text-2xl text-color-header-text">User</h2>
+        <TextField
+          name="user"
+          disabled={!selfUserIsSuperAdmin}
+          placeholder="Search..."
+          value={user || ""}
+          onChange={(e) => {
+            setUser(e.currentTarget.value);
+            setSidebarFilterText(e.currentTarget.value);
+          }}
+          onFocus={() => {
+            setSidebar(({ filterText }) => (
+              <SidebarSelectUser
+                users={users}
+                fieldValue={filterText}
+                selfEmail={selfUserEmail || ""}
+                setFieldValue={(value) => {
+                  setUser(value);
+                  setSidebar();
+                }}
+              />
+            ));
+          }}
+        />
+      </label>
+    </div>
+  );
+};

--- a/app/features/sherlock/role-assignments/view/role-assignment-details.tsx
+++ b/app/features/sherlock/role-assignments/view/role-assignment-details.tsx
@@ -1,0 +1,83 @@
+import type { SerializeFrom } from "@remix-run/node";
+import type {
+  SherlockRoleAssignmentV3,
+  SherlockRoleV3,
+} from "@sherlock-js-client/sherlock";
+import { AlertTriangle, BadgeCheck } from "lucide-react";
+import { MutateControls } from "../../mutate-controls";
+import { RoleColors } from "../../roles/role-colors";
+import { isRoleAssignmentExpired } from "../list/is-expired-or-suspended";
+
+export interface RoleAssignmentDetailsProps {
+  assignment:
+    | SherlockRoleAssignmentV3
+    | SerializeFrom<SherlockRoleAssignmentV3>;
+  role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>;
+  toEdit?: string;
+  toDelete?: string;
+}
+
+export const RoleAssignmentDetails: React.FunctionComponent<
+  RoleAssignmentDetailsProps
+> = ({ assignment, toEdit, toDelete }) => {
+  const isExpired = isRoleAssignmentExpired(assignment);
+  return (
+    <div className="flex flex-col space-y-4">
+      {assignment.suspended || isExpired ? (
+        <div className="flex flex-row space-x-2">
+          <h2 className="font-light text-2xl text-color-header-text">
+            Inactive
+          </h2>
+          <AlertTriangle className="stroke-color-status-yellow shrink-0 h-8 w-8" />
+        </div>
+      ) : (
+        <div className="flex flex-row space-x-2">
+          <h2 className="font-light text-2xl text-color-header-text">Active</h2>
+          <BadgeCheck className="stroke-color-status-green shrink-0 h-8 w-8" />
+        </div>
+      )}
+      {assignment.suspended && (
+        <p>
+          This assignment has been{" "}
+          <span className="font-medium">suspended</span>. Please check user
+          suitability.
+        </p>
+      )}
+      {isExpired && (
+        <p>
+          This assignment has <span className="font-medium">expired</span>.
+          Please check expiration.
+        </p>
+      )}
+      {!(assignment.suspended || isExpired) && (
+        <p>
+          This assignment is <span className="font-medium">active</span>.
+        </p>
+      )}
+      <h2 className="font-light text-2xl text-color-header-text">Expiry</h2>
+      {assignment.expiresAt ? (
+        <p>
+          This assignment{" "}
+          <span className="font-medium">
+            {isExpired ? "expired" : "will expire"}
+          </span>{" "}
+          at{" "}
+          <span className="font-medium">
+            {assignment.expiresAt.toString() || ""}
+          </span>
+        </p>
+      ) : (
+        <p>
+          <span className="font-extralight">None</span>
+        </p>
+      )}
+      {(toEdit || toDelete) && (
+        <MutateControls
+          colors={RoleColors}
+          toEdit={toEdit}
+          toDelete={toDelete}
+        />
+      )}
+    </div>
+  );
+};

--- a/app/features/sherlock/role-assignments/view/role-assignment-details.tsx
+++ b/app/features/sherlock/role-assignments/view/role-assignment-details.tsx
@@ -4,6 +4,7 @@ import type {
   SherlockRoleV3,
 } from "@sherlock-js-client/sherlock";
 import { AlertTriangle, BadgeCheck } from "lucide-react";
+import { PrettyPrintTime } from "~/components/logic/pretty-print-time";
 import { MutateControls } from "../../mutate-controls";
 import { RoleColors } from "../../roles/role-colors";
 import { isRoleAssignmentExpired } from "../list/is-expired-or-suspended";
@@ -13,20 +14,21 @@ export interface RoleAssignmentDetailsProps {
     | SherlockRoleAssignmentV3
     | SerializeFrom<SherlockRoleAssignmentV3>;
   role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>;
-  toEdit?: string;
-  toDelete?: string;
+  assignmentEditableBySelfUser: boolean;
+  toEdit: string;
+  toDelete: string;
 }
 
 export const RoleAssignmentDetails: React.FunctionComponent<
   RoleAssignmentDetailsProps
-> = ({ assignment, toEdit, toDelete }) => {
+> = ({ assignment, assignmentEditableBySelfUser, toEdit, toDelete }) => {
   const isExpired = isRoleAssignmentExpired(assignment);
   return (
     <div className="flex flex-col space-y-4">
       {assignment.suspended || isExpired ? (
         <div className="flex flex-row space-x-2">
           <h2 className="font-light text-2xl text-color-header-text">
-            Inactive
+            {assignment.suspended ? "Suspended" : "Expired"}
           </h2>
           <AlertTriangle className="stroke-color-status-yellow shrink-0 h-8 w-8" />
         </div>
@@ -39,14 +41,24 @@ export const RoleAssignmentDetails: React.FunctionComponent<
       {assignment.suspended && (
         <p>
           This assignment has been{" "}
-          <span className="font-medium">suspended</span>. Please check user
-          suitability.
+          <span className="font-medium">suspended</span>.
+          {assignmentEditableBySelfUser && (
+            <span>
+              {` `}Check user suitability or click "Edit Metadata" to enable
+              user.
+            </span>
+          )}
         </p>
       )}
       {isExpired && (
         <p>
-          This assignment has <span className="font-medium">expired</span>.
-          Please check expiration.
+          This assignment <span className="font-medium">expired</span> on{" "}
+          <PrettyPrintTime time={assignment.expiresAt} />.
+          {assignmentEditableBySelfUser && (
+            <span>
+              {` `}Click "Edit Metadata" to reset the expiration period.
+            </span>
+          )}
         </p>
       )}
       {!(assignment.suspended || isExpired) && (
@@ -54,24 +66,20 @@ export const RoleAssignmentDetails: React.FunctionComponent<
           This assignment is <span className="font-medium">active</span>.
         </p>
       )}
-      <h2 className="font-light text-2xl text-color-header-text">Expiry</h2>
-      {assignment.expiresAt ? (
-        <p>
-          This assignment{" "}
-          <span className="font-medium">
-            {isExpired ? "expired" : "will expire"}
-          </span>{" "}
-          at{" "}
-          <span className="font-medium">
-            {assignment.expiresAt.toString() || ""}
-          </span>
-        </p>
-      ) : (
-        <p>
-          <span className="font-extralight">None</span>
-        </p>
+      {!isExpired && (
+        <>
+          <h2 className="font-light text-2xl text-color-header-text">Expiry</h2>
+          {assignment.expiresAt ? (
+            <p>
+              This assignment <span className="font-medium">will expire</span>{" "}
+              on <PrettyPrintTime time={assignment.expiresAt} />.
+            </p>
+          ) : (
+            <span className="font-extralight">None</span>
+          )}
+        </>
       )}
-      {(toEdit || toDelete) && (
+      {assignmentEditableBySelfUser && (
         <MutateControls
           colors={RoleColors}
           toEdit={toEdit}

--- a/app/features/sherlock/roles/list/self-user-can-break-glass-into-role.ts
+++ b/app/features/sherlock/roles/list/self-user-can-break-glass-into-role.ts
@@ -1,0 +1,23 @@
+import type { SerializeFrom } from "@remix-run/node";
+import { SherlockRoleV3, SherlockUserV3 } from "@sherlock-js-client/sherlock";
+
+export function selfUserCanBreakGlassIntoRole(
+  selfUserEmail: string,
+  role: SherlockRoleV3 | SerializeFrom<SherlockRoleV3>,
+  roles: Array<SherlockRoleV3> | Array<SerializeFrom<SherlockRoleV3>>,
+): boolean {
+  if (!role.canBeGlassBrokenByRole) {
+    return false;
+  }
+  const breakGlassRole = roles.find(
+    (r) => r.id === role.canBeGlassBrokenByRole,
+  );
+  if (breakGlassRole === undefined) {
+    return false;
+  }
+  return (
+    breakGlassRole.assignments?.some(
+      (a) => (a.userInfo as SherlockUserV3).email === selfUserEmail,
+    ) || false
+  );
+}

--- a/app/features/sherlock/roles/view/role-details.tsx
+++ b/app/features/sherlock/roles/view/role-details.tsx
@@ -1,7 +1,6 @@
 import type { SerializeFrom } from "@remix-run/node";
 import type { SherlockRoleV3 } from "@sherlock-js-client/sherlock";
 import { NavButton } from "~/components/interactivity/nav-button";
-import { ChartReleaseColors } from "../../chart-releases/chart-release-colors";
 import { MutateControls } from "../../mutate-controls";
 import { RoleColors } from "../role-colors";
 
@@ -25,7 +24,7 @@ export const RoleDetails: React.FunctionComponent<RoleDetailsProps> = ({
   return (
     <div className="flex flex-col space-y-4">
       {toAssignments && (
-        <NavButton to={toAssignments} {...ChartReleaseColors}>
+        <NavButton to={toAssignments} {...RoleColors}>
           <h2>View Assignments in This Role</h2>
         </NavButton>
       )}

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -77,6 +77,10 @@ export default function Route() {
           Users
         </NavLink>
         <span className="hidden laptop:inline laptop:last:hidden">•</span>
+        <NavLink to="/roles" prefetch="intent">
+          Roles
+        </NavLink>
+        <span className="hidden laptop:inline laptop:last:hidden">•</span>
         <NavLink to="/pagerduty-integrations" prefetch="intent">
           PagerDuty
         </NavLink>

--- a/app/routes/_layout.roles.$roleName.assignments.$userEmail.delete.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.$userEmail.delete.tsx
@@ -1,0 +1,73 @@
+import type { ActionFunctionArgs, MetaFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import type { Params } from "@remix-run/react";
+import { NavLink, useActionData } from "@remix-run/react";
+import { RoleAssignmentsApi } from "@sherlock-js-client/sherlock";
+import { DeletionGuard } from "~/components/interactivity/deletion-guard";
+import { OutsetFiller } from "~/components/layout/outset-filler";
+import { OutsetPanel } from "~/components/layout/outset-panel";
+import { ActionBox } from "~/components/panel-structures/action-box";
+import { PanelErrorBoundary } from "~/errors/components/error-boundary";
+import { FormErrorDisplay } from "~/errors/components/form-error-display";
+import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
+import { RoleAssignmentDeleteDescription } from "~/features/sherlock/role-assignments/delete/role-assignment-delete-description";
+import { RoleColors } from "~/features/sherlock/roles/role-colors";
+import { SherlockConfiguration } from "~/features/sherlock/sherlock.server";
+import { getValidSession } from "~/helpers/get-valid-session.server";
+import { useRoleAssignmentContext } from "./_layout.roles.$roleName.assignments.$userEmail";
+
+export const handle = {
+  breadcrumb: (params: Readonly<Params<string>>) => (
+    <NavLink
+      to={`/roles/${params.roleName}/assignments/${params.userEmail}/delete`}
+    >
+      Delete
+    </NavLink>
+  ),
+};
+
+export const meta: MetaFunction = ({ params }) => [
+  { title: `${params.userEmail} - Assignmnet - Delete` },
+];
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  await getValidSession(request);
+
+  return new RoleAssignmentsApi(SherlockConfiguration)
+    .apiRoleAssignmentsV3RoleSelectorUserSelectorDelete({
+      userSelector: params.userEmail || "",
+      roleSelector: params.roleName || "",
+    })
+    .then(
+      () => redirect(`/roles/${params.roleName}/assignments`),
+      makeErrorResponseReturner(),
+    );
+}
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export default function Route() {
+  const { role, user, assignment } = useRoleAssignmentContext();
+
+  const errorInfo = useActionData<typeof action>();
+  return (
+    <>
+      <OutsetPanel>
+        <ActionBox
+          title={`Now Deleting ${role.name} assignment for ${user.email}`}
+          submitText={`Click to Delete`}
+          {...RoleColors}
+        >
+          <RoleAssignmentDeleteDescription
+            role={role}
+            user={user}
+            assignment={assignment}
+          />
+          <DeletionGuard name={user.email + " assignment"} />
+          {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
+        </ActionBox>
+      </OutsetPanel>
+      <OutsetFiller />
+    </>
+  );
+}

--- a/app/routes/_layout.roles.$roleName.assignments.$userEmail.delete.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.$userEmail.delete.tsx
@@ -63,7 +63,7 @@ export default function Route() {
             user={user}
             assignment={assignment}
           />
-          <DeletionGuard name={user.email + " assignment"} />
+          <DeletionGuard name={"assignment"} />
           {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
         </ActionBox>
       </OutsetPanel>

--- a/app/routes/_layout.roles.$roleName.assignments.$userEmail.edit.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.$userEmail.edit.tsx
@@ -1,0 +1,79 @@
+import type { ActionFunctionArgs, MetaFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import type { Params } from "@remix-run/react";
+import { NavLink, useActionData } from "@remix-run/react";
+import { RoleAssignmentsApi } from "@sherlock-js-client/sherlock";
+
+import { OutsetPanel } from "~/components/layout/outset-panel";
+import { ActionBox } from "~/components/panel-structures/action-box";
+import { PanelErrorBoundary } from "~/errors/components/error-boundary";
+import { FormErrorDisplay } from "~/errors/components/form-error-display";
+import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
+import {
+  RoleAssignmentEditableFields,
+  roleAssignmentEditableFormDataToObject,
+} from "~/features/sherlock/role-assignments/edit/role-assignment-editable-fields";
+import { RoleColors } from "~/features/sherlock/roles/role-colors";
+import { SherlockConfiguration } from "~/features/sherlock/sherlock.server";
+import { getValidSession } from "~/helpers/get-valid-session.server";
+import { useRoleAssignmentContext } from "./_layout.roles.$roleName.assignments.$userEmail";
+
+export const handle = {
+  breadcrumb: (params: Readonly<Params<string>>) => (
+    <NavLink
+      to={`/roles/${params.roleName}/assignments/${params.userEmail}/edit`}
+    >
+      Edit
+    </NavLink>
+  ),
+};
+
+export const meta: MetaFunction = ({ params }) => [
+  { title: `${params.userEmail} - Role Assignment - Edit` },
+];
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  await getValidSession(request);
+
+  const formData = await request.formData();
+  const assignment = roleAssignmentEditableFormDataToObject(formData);
+
+  return new RoleAssignmentsApi(SherlockConfiguration)
+    .apiRoleAssignmentsV3RoleSelectorUserSelectorPatch({
+      userSelector: params.userEmail || "",
+      roleSelector: params.roleName || "",
+      roleAssignment: assignment,
+    })
+    .then(
+      () =>
+        redirect(`/roles/${params.roleName}/assignments/${params.userEmail}`),
+      makeErrorResponseReturner(assignment),
+    );
+}
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export default function Route() {
+  const { role, user, selfUserIsSuperAdmin, assignment } =
+    useRoleAssignmentContext();
+  const errorInfo = useActionData<typeof action>();
+
+  return (
+    <>
+      <OutsetPanel>
+        <ActionBox
+          title={`Edit Assignment`}
+          submitText="Click to Save Edits"
+          {...RoleColors}
+        >
+          <RoleAssignmentEditableFields
+            role={role}
+            assignment={errorInfo?.formState || assignment}
+            selfUserIsSuperAdmin={selfUserIsSuperAdmin}
+          />
+          {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
+        </ActionBox>
+      </OutsetPanel>
+    </>
+  );
+}

--- a/app/routes/_layout.roles.$roleName.assignments.$userEmail.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.$userEmail.tsx
@@ -55,7 +55,7 @@ export const ErrorBoundary = PanelErrorBoundary;
 export default function Route() {
   const params = useParams();
   const context = useRoleContext();
-  const { role, roles } = context;
+  const { role, selfUser, selfUserIsSuperAdmin } = context;
 
   const assignment = (role.assignments || []).find(
     (a) => (a.userInfo as SherlockUserV3).email == params.userEmail,
@@ -70,6 +70,10 @@ export default function Route() {
   }
   const user = assignment.userInfo as SherlockUserV3;
 
+  const assignmentEditableBySelfUser =
+    selfUserIsSuperAdmin ||
+    (user.email === selfUser.email && !!role.canBeGlassBrokenByRole);
+
   return (
     <>
       <OutsetPanel {...RoleColors}>
@@ -82,12 +86,15 @@ export default function Route() {
           <RoleAssignmentDetails
             role={role}
             assignment={assignment}
-            toEdit="./edit"
+            assignmentEditableBySelfUser={assignmentEditableBySelfUser}
+            toEdit={"./edit"}
             toDelete={"./delete"}
           />
         </ItemDetails>
       </OutsetPanel>
-      <Outlet context={{ user, assignment, ...context }} />
+      <Outlet
+        context={{ user, assignment, assignmentEditableBySelfUser, ...context }}
+      />
     </>
   );
 }
@@ -96,5 +103,6 @@ export const useRoleAssignmentContext = useOutletContext<
   {
     user: SerializeFrom<SherlockUserV3>;
     assignment: SerializeFrom<SherlockRoleAssignmentV3>;
+    assignmentEditableBySelfUser: boolean;
   } & ReturnType<typeof useRoleContext>
 >;

--- a/app/routes/_layout.roles.$roleName.assignments.new.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.new.tsx
@@ -1,0 +1,135 @@
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { NavLink, useActionData, useLoaderData } from "@remix-run/react";
+import {
+  RoleAssignmentsApi,
+  SherlockUserV3,
+  UsersApi,
+} from "@sherlock-js-client/sherlock";
+import { useState } from "react";
+import { InsetPanel } from "~/components/layout/inset-panel";
+import { OutsetPanel } from "~/components/layout/outset-panel";
+import { ActionBox } from "~/components/panel-structures/action-box";
+import { FillerText } from "~/components/panel-structures/filler-text";
+import { PanelErrorBoundary } from "~/errors/components/error-boundary";
+import { FormErrorDisplay } from "~/errors/components/form-error-display";
+import {
+  errorResponseThrower,
+  makeErrorResponseReturner,
+} from "~/errors/helpers/error-response-handlers";
+import {
+  RoleAssignmentEditableFields,
+  roleAssignmentEditableFormDataToObject,
+} from "~/features/sherlock/role-assignments/edit/role-assignment-editable-fields";
+import { RoleAssignmentCreatableFields } from "~/features/sherlock/role-assignments/new/role-assignment-creatable-fields";
+import { RoleColors } from "~/features/sherlock/roles/role-colors";
+import { RoleHelpCopy } from "~/features/sherlock/roles/role-help-copy";
+import {
+  SherlockConfiguration,
+  handleIAP,
+} from "~/features/sherlock/sherlock.server";
+import { getValidSession } from "~/helpers/get-valid-session.server";
+import { useSidebar } from "~/hooks/use-sidebar";
+import { useRoleContext } from "./_layout.roles.$roleName";
+
+export const handle = {
+  breadcrumb: () => <NavLink to="/roles/new">New</NavLink>,
+};
+
+export const meta: MetaFunction = () => [
+  {
+    title: "New Role",
+  },
+];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return new UsersApi(SherlockConfiguration)
+    .apiUsersV3Get({}, handleIAP(request))
+    .catch(errorResponseThrower);
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  await getValidSession(request);
+
+  const formData = await request.formData();
+  const roleAssignmentRequest =
+    roleAssignmentEditableFormDataToObject(formData);
+  const userEmail = formData.get("user")?.toString();
+
+  return new RoleAssignmentsApi(SherlockConfiguration)
+    .apiRoleAssignmentsV3RoleSelectorUserSelectorPost({
+      userSelector: userEmail || "",
+      roleSelector: params.roleName || "",
+      roleAssignment: roleAssignmentRequest,
+    })
+    .then(
+      () => redirect(`/roles/${params.roleName}/assignments/${userEmail}`),
+      makeErrorResponseReturner(roleAssignmentRequest),
+    );
+}
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export default function Route() {
+  const users = useLoaderData<typeof loader>();
+  const { role, selfUser, selfUserIsSuperAdmin } = useRoleContext();
+
+  const errorInfo = useActionData<typeof action>();
+  const errUserEmail = (errorInfo?.formState?.userInfo as SherlockUserV3)
+    ?.email;
+
+  const [user, setUser] = useState(errUserEmail || selfUser?.email);
+
+  const {
+    setSidebarFilterText,
+    setSidebar,
+    isSidebarPresent,
+    SidebarComponent,
+  } = useSidebar();
+
+  return (
+    <>
+      <OutsetPanel {...RoleColors}>
+        <ActionBox
+          title="New Role Assignment"
+          submitText="Click to Create"
+          {...RoleColors}
+        >
+          <RoleAssignmentCreatableFields
+            user={user}
+            setUser={setUser}
+            users={users}
+            selfUserEmail={selfUser?.email}
+            selfUserIsSuperAdmin={selfUserIsSuperAdmin}
+            setSidebar={setSidebar}
+            setSidebarFilterText={setSidebarFilterText}
+          />
+          <RoleAssignmentEditableFields
+            assignment={
+              errorInfo?.formState || {
+                suspended: false,
+                expiresIn: role.defaultGlassBreakDuration,
+              }
+            }
+            role={role}
+            selfUserIsSuperAdmin={selfUserIsSuperAdmin}
+          />
+          {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
+        </ActionBox>
+      </OutsetPanel>
+      <InsetPanel largeScreenOnly={!isSidebarPresent}>
+        {isSidebarPresent ? (
+          <SidebarComponent />
+        ) : (
+          <FillerText>
+            <RoleHelpCopy />
+          </FillerText>
+        )}
+      </InsetPanel>
+    </>
+  );
+}

--- a/app/routes/_layout.roles.$roleName.assignments.new.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.new.tsx
@@ -117,6 +117,7 @@ export default function Route() {
             }
             role={role}
             selfUserIsSuperAdmin={selfUserIsSuperAdmin}
+            creating={true}
           />
           {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
         </ActionBox>

--- a/app/routes/_layout.roles.$roleName.assignments.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.tsx
@@ -42,7 +42,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function Route() {
   const context = useRoleContext();
-  const role = context.role;
+  const { role, roleAssignableBySelfUser } = context;
 
   const params = useParams();
   const [filterText, setFilterText] = useState("");
@@ -60,8 +60,8 @@ export default function Route() {
         >
           <ListControls
             setFilterText={setFilterText}
-            toCreate="./new"
-            toCreateText="Add New"
+            toCreate={roleAssignableBySelfUser ? "./new" : undefined}
+            toCreateText={roleAssignableBySelfUser ? "Add New" : undefined}
             {...RoleColors}
           />
           <MemoryFilteredList

--- a/app/routes/_layout.roles.$roleName.assignments.tsx
+++ b/app/routes/_layout.roles.$roleName.assignments.tsx
@@ -1,0 +1,87 @@
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import type { Params } from "@remix-run/react";
+import { NavLink, Outlet, useParams } from "@remix-run/react";
+import { SherlockUserV3, UsersApi } from "@sherlock-js-client/sherlock";
+import { useState } from "react";
+import { ListControls } from "~/components/interactivity/list-controls";
+import { NavButton } from "~/components/interactivity/nav-button";
+import { InsetPanel } from "~/components/layout/inset-panel";
+import { MemoryFilteredList } from "~/components/logic/memory-filtered-list";
+import { InteractiveList } from "~/components/panel-structures/interactive-list";
+import { errorResponseThrower } from "~/errors/helpers/error-response-handlers";
+import { ListRoleAssignmentUserButtonText } from "~/features/sherlock/role-assignments/list/list-role-assignment-user-button-text";
+import { matchRoleAssignmentByUser } from "~/features/sherlock/role-assignments/list/match-role-assignment-by-user";
+import { makeRoleAssignmentSorterForUser } from "~/features/sherlock/role-assignments/list/role-assignment-sorter";
+import { RoleColors } from "~/features/sherlock/roles/role-colors";
+import {
+  SherlockConfiguration,
+  handleIAP,
+} from "~/features/sherlock/sherlock.server";
+import { PanelErrorBoundary } from "../errors/components/error-boundary";
+import { useRoleContext } from "./_layout.roles.$roleName";
+
+export const handle = {
+  breadcrumb: (params: Readonly<Params<string>>) => (
+    <NavLink to={`/roles/${params.roleName}/assignments`}>Assignments</NavLink>
+  ),
+};
+
+export const meta: MetaFunction = ({ params }) => [
+  {
+    title: `${params.roleName} - Role - Assignments`,
+  },
+];
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  return new UsersApi(SherlockConfiguration)
+    .apiUsersV3SelectorGet({ selector: "self" }, handleIAP(request))
+    .catch(errorResponseThrower);
+}
+
+export default function Route() {
+  const context = useRoleContext();
+  const role = context.role;
+
+  const params = useParams();
+  const [filterText, setFilterText] = useState("");
+
+  const sortedAssignments = (role.assignments || []).sort(
+    makeRoleAssignmentSorterForUser(context.selfUser.email),
+  );
+
+  return (
+    <>
+      <InsetPanel alwaysShowScrollbar>
+        <InteractiveList
+          title={`Assignments in ${params.roleName}`}
+          {...RoleColors}
+        >
+          <ListControls
+            setFilterText={setFilterText}
+            toCreate="./new"
+            toCreateText="Add New"
+            {...RoleColors}
+          />
+          <MemoryFilteredList
+            entries={sortedAssignments}
+            filterText={filterText}
+            filter={matchRoleAssignmentByUser}
+          >
+            {(roleAssn, index) => (
+              <NavButton
+                to={`./${(roleAssn.userInfo as SherlockUserV3).email}`}
+                key={index.toString()}
+                {...RoleColors}
+              >
+                <ListRoleAssignmentUserButtonText roleAssn={roleAssn} />
+              </NavButton>
+            )}
+          </MemoryFilteredList>
+        </InteractiveList>
+      </InsetPanel>
+      <Outlet context={context} />
+    </>
+  );
+}

--- a/app/routes/_layout.roles.$roleName.tsx
+++ b/app/routes/_layout.roles.$roleName.tsx
@@ -14,6 +14,7 @@ import {
 import { RolesApi } from "@sherlock-js-client/sherlock";
 import { OutsetPanel } from "~/components/layout/outset-panel";
 import { ItemDetails } from "~/components/panel-structures/item-details";
+import { selfUserCanBreakGlassIntoRole } from "~/features/sherlock/roles/list/self-user-can-break-glass-into-role";
 import { RoleColors } from "~/features/sherlock/roles/role-colors";
 import { RoleDetails } from "~/features/sherlock/roles/view/role-details";
 import {
@@ -49,6 +50,11 @@ export const ErrorBoundary = PanelErrorBoundary;
 export default function Route() {
   const { role } = useLoaderData<typeof loader>();
   const context = useRolesContext();
+  const { roles, selfUser, selfUserIsSuperAdmin } = context;
+
+  const roleAssignableBySelfUser =
+    selfUserIsSuperAdmin ||
+    selfUserCanBreakGlassIntoRole(selfUser.email || "", role, roles);
 
   return (
     <>
@@ -62,12 +68,12 @@ export default function Route() {
           <RoleDetails
             role={role}
             toAssignments="./assignments"
-            toEdit="./edit"
-            toDelete={"./delete"}
+            toEdit={selfUserIsSuperAdmin ? "./edit" : undefined}
+            toDelete={selfUserIsSuperAdmin ? "./delete" : undefined}
           />
         </ItemDetails>
       </OutsetPanel>
-      <Outlet context={{ role, ...context }} />
+      <Outlet context={{ role, roleAssignableBySelfUser, ...context }} />
     </>
   );
 }
@@ -75,5 +81,6 @@ export default function Route() {
 export const useRoleContext = useOutletContext<
   {
     role: SerializeFrom<typeof loader>["role"];
+    roleAssignableBySelfUser: boolean;
   } & ReturnType<typeof useRolesContext>
 >;

--- a/app/routes/_layout.roles.tsx
+++ b/app/routes/_layout.roles.tsx
@@ -54,7 +54,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const superAdminRoles = roles.filter((r) => r.grantsSherlockSuperAdmin);
 
-  const selfUserIsSuperAdmin = await Promise.all(
+  const selfUserInSuperAdminGroups = await Promise.all(
     superAdminRoles.map((r) => {
       return new RoleAssignmentsApi(SherlockConfiguration)
         .apiRoleAssignmentsV3RoleSelectorUserSelectorGet(
@@ -76,7 +76,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return {
     roles: roles,
     selfUser: selfUser,
-    selfUserIsSuperAdmin: selfUserIsSuperAdmin.some((r) => r),
+    selfUserIsSuperAdmin: false, //selfUserInSuperAdminGroups.some((r) => r),
   };
 }
 
@@ -84,7 +84,7 @@ export const ErrorBoundary = PanelErrorBoundary;
 
 export default function Route() {
   const context = useLoaderData<typeof loader>();
-  const roles = context.roles;
+  const { roles, selfUserIsSuperAdmin } = context;
   const { roleName: currentPathRole } = useParams();
   const [filterText, setFilterText] = useState("");
   return (
@@ -93,7 +93,7 @@ export default function Route() {
         <InteractiveList title="Roles" {...RoleColors}>
           <ListControls
             setFilterText={setFilterText}
-            toCreate="./new"
+            toCreate={selfUserIsSuperAdmin ? "./new" : undefined}
             {...RoleColors}
           />
           <MemoryFilteredList

--- a/app/routes/_layout.roles.tsx
+++ b/app/routes/_layout.roles.tsx
@@ -76,7 +76,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return {
     roles: roles,
     selfUser: selfUser,
-    selfUserIsSuperAdmin: false, //selfUserInSuperAdminGroups.some((r) => r),
+    selfUserIsSuperAdmin: selfUserInSuperAdminGroups.some((r) => r),
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@remix-run/node": "^v2.7.2",
         "@remix-run/react": "^v2.7.2",
         "@remix-run/serve": "^v2.7.2",
-        "@sherlock-js-client/sherlock": "^1.4.0",
+        "@sherlock-js-client/sherlock": "^1.4.7",
         "lucide-react": "^0.340.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2610,9 +2610,9 @@
       "dev": true
     },
     "node_modules/@sherlock-js-client/sherlock": {
-      "version": "1.4.0",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-1.4.0.tgz",
-      "integrity": "sha512-YTO/IiUvPnSnDnuVwh2YFfuWOMwe0ADwx8yEemUxrwkoHDVHEZU+6zkubO+25yEwNFxQu7U+k3wrFEI9fKBAWw=="
+      "version": "1.4.7",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-1.4.7.tgz",
+      "integrity": "sha512-tka7UIEeD2fJ1wF6Hl3V3xttdMqM4bLnPBTSjYoS8llBInuaT5ZxSwJ/euggfyyAjJwxKiYseZMY69xdE/f7IQ=="
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@remix-run/node": "^v2.7.2",
     "@remix-run/react": "^v2.7.2",
     "@remix-run/serve": "^v2.7.2",
-    "@sherlock-js-client/sherlock": "^1.4.0",
+    "@sherlock-js-client/sherlock": "^1.4.7",
     "lucide-react": "^0.340.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
First pass at a role assignments UI for Beehive. This PR also adds a link to the Roles view from the front page.

There are two flavors of experience. Sherlock Super Admins can universally create/edit/delete roles and assignments ([video](https://github.com/broadinstitute/beehive/assets/60902147/a69270fc-dd0f-45d9-bce2-c24931d897fa)). Regular users can create/edit/delete role assignments, but only for themselves, in roles that they can break-glass into ([video](https://github.com/broadinstitute/beehive/assets/60902147/000be1b3-6919-4c36-83b3-cc4c862469dc
)).

Note that this distinction is purely for improved UX, permission controls are implemented server-side.