### PR TITLE
[DDO-3748] Document two-reviewer

### DIFF
--- a/.github/workflows/dependabot-approve.yaml
+++ b/.github/workflows/dependabot-approve.yaml
@@ -1,0 +1,25 @@
+name: Dependabot Approve
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR as Dependabot
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,5 @@ All testing here is manual. It's not ideal but it's the reality of how this code
 ## Submitting Changes
 
 PRs require a ticket in the title with CLIA risk and security impact description filled. The description must include a summary of the changes, an explanation of what testing was done (screenshots recommended), and a note on the risk of the change.
+
+PRs require two approvals; dependabot PRs only require one (GitHub Actions will automatically lend one approval to make this work with branch protection rules).


### PR DESCRIPTION
Documents two-reviewer rule; adds GHA that lends an approval to dependabot PRs to make that smoother