### PR TITLE
[DDO-3754] Allow programmatically bypassing GitHub login

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -156,8 +156,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
-  // Start GitHub OAuth
-  if (!session.has(sessionFields.githubAccessToken)) {
+  // Start GitHub OAuth, assuming X-Beehive-Ignore-Github isn't set
+  if (
+    !session.has(sessionFields.githubAccessToken) &&
+    !request.headers.has("X-Beehive-Ignore-Github")
+  ) {
     session.set(sessionFields.githubOAuthState, generateNonce());
     const githubAuthorizeURL = new URL(
       "https://github.com/login/oauth/authorize",


### PR DESCRIPTION
...by setting an `X-Beehive-Ignore-Github` header. This is helpful for automatic scanning of Beehive. Sarah G knows that bypassing this will break parts of Beehive, that's okay by her.

## Testing

Tested locally. The misc page does indeed break a little bit as expected, I'm sure others would too. No one will accidentally trigger this so I think it's fine.

## Risk

Low