### PR TITLE
[DDO-3777] Remove prefetch-src from CSP

### DIFF
--- a/app/helpers/csp.server.ts
+++ b/app/helpers/csp.server.ts
@@ -24,7 +24,6 @@ export function getContentSecurityPolicy(nonce?: string | undefined): string {
     `connect-src ${connectSrc}; ` +
     `media-src ${self}; ` +
     "object-src 'none'; " +
-    `prefetch-src ${self}; ` +
     `child-src ${self}; ` +
     `frame-src ${self}; ` +
     `worker-src ${self} blob:; ` +


### PR DESCRIPTION
Per Sarah G this is deprecated and it's now showing up as a low finding in Zap. Browsers that support it will fall back to default-src [(which we set to the same thing)](https://github.com/broadinstitute/beehive/blob/main/app/helpers/csp.server.ts#L19) so this is very safe to do.

## Testing

"it loads" (CSP is the same everywhere so 🤷)

## Risk

Astoundingly low