### PR TITLE
[DDO-3776] Environment/Cluster Required Role UI

### DIFF
--- a/app/features/sherlock/clusters/cluster-edit-help-copy.tsx
+++ b/app/features/sherlock/clusters/cluster-edit-help-copy.tsx
@@ -1,0 +1,12 @@
+export const ClusterEditHelpCopy: React.FunctionComponent = () => (
+  <>
+    <p>
+      These settings don't directly impact the cluster itself, just how we
+      deploy to it.
+    </p>
+    <p>
+      There's other setup necessary for the DevOps platform to be able to deploy
+      to a cluster, so contact us if you're trying to set something new up.
+    </p>
+  </>
+);

--- a/app/features/sherlock/clusters/edit/cluster-editable-fields.tsx
+++ b/app/features/sherlock/clusters/edit/cluster-editable-fields.tsx
@@ -1,19 +1,28 @@
 import type { SerializeFrom } from "@remix-run/node";
-import type { SherlockClusterV3 } from "@sherlock-js-client/sherlock";
+import type {
+  SherlockClusterV3,
+  SherlockRoleV3,
+} from "@sherlock-js-client/sherlock";
 import { useState } from "react";
 import { EnumInputSelect } from "~/components/interactivity/enum-select";
 import { TextField } from "~/components/interactivity/text-field";
+import type { SetsSidebarProps } from "~/hooks/use-sidebar";
+import { SidebarSelectRole } from "../../roles/set/sidebar-select-role";
 import { ClusterColors } from "../cluster-colors";
 
 export interface ClusterEditableFieldsProps {
   cluster?: SherlockClusterV3 | SerializeFrom<SherlockClusterV3>;
+  roles: SerializeFrom<SherlockRoleV3[]>;
 }
 
 export const ClusterEditableFields: React.FunctionComponent<
-  ClusterEditableFieldsProps
-> = ({ cluster }) => {
+  ClusterEditableFieldsProps & SetsSidebarProps
+> = ({ setSidebarFilterText, setSidebar, cluster, roles }) => {
   const [requiresSuitability, setRequiresSuitability] = useState(
     cluster?.requiresSuitability === true ? "true" : "false",
+  );
+  const [requiredRole, setRequiredRole] = useState(
+    cluster?.requiredRole != null ? cluster.requiredRole : "",
   );
   return (
     <div className="flex flex-col space-y-4">
@@ -95,6 +104,37 @@ export const ClusterEditableFields: React.FunctionComponent<
             ["No", "false"],
           ]}
           {...ClusterColors}
+        />
+      </div>
+      <div>
+        <h2 className="font-light text-2xl text-color-header-text">
+          Require Role?
+        </h2>
+        <p>
+          DevOps's systems can require active membership in a specific role to{" "}
+          <b className="font-semibold">modify</b> this cluster (doesn't affect
+          access).
+        </p>
+        <TextField
+          name="requiredRole"
+          placeholder="Search..."
+          value={requiredRole}
+          onChange={(e) => {
+            setRequiredRole(e.currentTarget.value);
+            setSidebarFilterText(e.currentTarget.value);
+          }}
+          onFocus={() => {
+            setSidebar(({ filterText }) => (
+              <SidebarSelectRole
+                roles={roles}
+                fieldValue={filterText}
+                setFieldValue={(value) => {
+                  setRequiredRole(value?.name || "");
+                  setSidebar();
+                }}
+              />
+            ));
+          }}
         />
       </div>
       <label>

--- a/app/features/sherlock/environments/edit/edit-environment-sidebar-modes.ts
+++ b/app/features/sherlock/environments/edit/edit-environment-sidebar-modes.ts
@@ -1,3 +1,0 @@
-export type EditEnvironmentSidebarModes =
-  | "select default cluster"
-  | "help text";

--- a/app/features/sherlock/environments/edit/environment-editable-fields.tsx
+++ b/app/features/sherlock/environments/edit/environment-editable-fields.tsx
@@ -2,6 +2,7 @@ import type { SerializeFrom } from "@remix-run/node";
 import type {
   SherlockClusterV3,
   SherlockEnvironmentV3,
+  SherlockRoleV3,
   SherlockUserV3,
 } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
@@ -11,6 +12,7 @@ import { TextField } from "~/components/interactivity/text-field";
 import { PrettyPrintDescription } from "~/components/logic/pretty-print-description";
 import type { SetsSidebarProps } from "~/hooks/use-sidebar";
 import { SidebarSelectCluster } from "../../clusters/set/sidebar-select-cluster";
+import { SidebarSelectRole } from "../../roles/set/sidebar-select-role";
 import { SidebarSelectUser } from "../../users/set/sidebar-select-user";
 import { EnvironmentColors } from "../environment-colors";
 
@@ -18,6 +20,7 @@ export interface EnvironmentEditableFieldsProps {
   environment?: SherlockEnvironmentV3 | SerializeFrom<SherlockEnvironmentV3>;
   clusters: SerializeFrom<SherlockClusterV3[]>;
   users: SerializeFrom<SherlockUserV3[]>;
+  roles: SerializeFrom<SherlockRoleV3[]>;
   // When we're creating an environment, we don't want to try to replicate Sherlock's
   // advanced template-default behavior, so this flag tells us to let the user pass
   // empty values for fields where we might otherwise block it.
@@ -39,6 +42,7 @@ export const EnvironmentEditableFields: React.FunctionComponent<
   environment,
   clusters,
   users,
+  roles,
   creating,
   templateInUse,
   defaultCluster,
@@ -49,6 +53,9 @@ export const EnvironmentEditableFields: React.FunctionComponent<
     environment?.requiresSuitability != null
       ? environment.requiresSuitability.toString()
       : "false",
+  );
+  const [requiredRole, setRequiredRole] = useState(
+    environment?.requiredRole != null ? environment.requiredRole : "",
   );
   const [owner, setOwner] = useState(environment?.owner || selfEmail || "");
   const [namePrefixesDomain, setNamePrefixesDomain] = useState(
@@ -85,6 +92,37 @@ export const EnvironmentEditableFields: React.FunctionComponent<
             ["No", "false"],
           ]}
           {...EnvironmentColors}
+        />
+      </div>
+      <div>
+        <h2 className="font-light text-2xl text-color-header-text">
+          Require Role?
+        </h2>
+        <p>
+          DevOps's systems can require active membership in a specific role to{" "}
+          <b className="font-semibold">modify</b> this environment (doesn't
+          affect access).
+        </p>
+        <TextField
+          name="requiredRole"
+          placeholder="Search..."
+          value={requiredRole}
+          onChange={(e) => {
+            setRequiredRole(e.currentTarget.value);
+            setSidebarFilterText(e.currentTarget.value);
+          }}
+          onFocus={() => {
+            setSidebar(({ filterText }) => (
+              <SidebarSelectRole
+                roles={roles}
+                fieldValue={filterText}
+                setFieldValue={(value) => {
+                  setRequiredRole(value?.name || "");
+                  setSidebar();
+                }}
+              />
+            ));
+          }}
         />
       </div>
       <label>

--- a/app/features/sherlock/roles/set/sidebar-select-role.tsx
+++ b/app/features/sherlock/roles/set/sidebar-select-role.tsx
@@ -1,5 +1,5 @@
 import type { SerializeFrom } from "@remix-run/node";
-import { SherlockRoleV3 } from "@sherlock-js-client/sherlock";
+import type { SherlockRoleV3 } from "@sherlock-js-client/sherlock";
 import { SidebarFilterControlledList } from "~/components/panel-structures/sidebar-filter-controlled-list";
 import { ListRoleButtonText } from "../list/list-role-button-text";
 import { matchRole } from "../list/match-role";

--- a/app/routes/_layout.clusters.$clusterName.edit.tsx
+++ b/app/routes/_layout.clusters.$clusterName.edit.tsx
@@ -1,24 +1,35 @@
-import type { ActionFunctionArgs, MetaFunction } from "@remix-run/node";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import type { Params } from "@remix-run/react";
-import { NavLink, useActionData } from "@remix-run/react";
+import { NavLink, useActionData, useLoaderData } from "@remix-run/react";
 import type { SherlockClusterV3 } from "@sherlock-js-client/sherlock";
-import { ClustersApi } from "@sherlock-js-client/sherlock";
+import { ClustersApi, RolesApi } from "@sherlock-js-client/sherlock";
+import { InsetPanel } from "~/components/layout/inset-panel";
 import { OutsetFiller } from "~/components/layout/outset-filler";
 
 import { OutsetPanel } from "~/components/layout/outset-panel";
 import { ActionBox } from "~/components/panel-structures/action-box";
+import { FillerText } from "~/components/panel-structures/filler-text";
 import { PanelErrorBoundary } from "~/errors/components/error-boundary";
 import { FormErrorDisplay } from "~/errors/components/form-error-display";
-import { makeErrorResponseReturner } from "~/errors/helpers/error-response-handlers";
+import {
+  errorResponseThrower,
+  makeErrorResponseReturner,
+} from "~/errors/helpers/error-response-handlers";
 import { ClusterColors } from "~/features/sherlock/clusters/cluster-colors";
+import { ClusterEditHelpCopy } from "~/features/sherlock/clusters/cluster-edit-help-copy";
 import { ClusterEditableFields } from "~/features/sherlock/clusters/edit/cluster-editable-fields";
 import {
-  handleIAP,
   SherlockConfiguration,
+  handleIAP,
 } from "~/features/sherlock/sherlock.server";
 import { formDataToObject } from "~/helpers/form-data-to-object.server";
 import { getValidSession } from "~/helpers/get-valid-session.server";
+import { useSidebar } from "~/hooks/use-sidebar";
 import { useClusterContext } from "~/routes/_layout.clusters.$clusterName";
 
 export const handle = {
@@ -30,6 +41,12 @@ export const handle = {
 export const meta: MetaFunction = ({ params }) => [
   { title: `${params.clusterName} - Cluster - Edit` },
 ];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return new RolesApi(SherlockConfiguration)
+    .apiRolesV3Get({}, handleIAP(request))
+    .catch(errorResponseThrower);
+}
 
 export async function action({ request, params }: ActionFunctionArgs) {
   await getValidSession(request);
@@ -54,8 +71,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
 export const ErrorBoundary = PanelErrorBoundary;
 
 export default function Route() {
+  const roles = useLoaderData<typeof loader>();
   const { cluster } = useClusterContext();
   const errorInfo = useActionData<typeof action>();
+
+  const {
+    setSidebarFilterText,
+    setSidebar,
+    isSidebarPresent,
+    SidebarComponent,
+  } = useSidebar();
+
   return (
     <>
       <OutsetPanel>
@@ -64,10 +90,24 @@ export default function Route() {
           submitText="Click to Save Edits"
           {...ClusterColors}
         >
-          <ClusterEditableFields cluster={errorInfo?.formState || cluster} />
+          <ClusterEditableFields
+            setSidebar={setSidebar}
+            setSidebarFilterText={setSidebarFilterText}
+            cluster={errorInfo?.formState || cluster}
+            roles={roles}
+          />
           {errorInfo && <FormErrorDisplay {...errorInfo.errorSummary} />}
         </ActionBox>
       </OutsetPanel>
+      <InsetPanel largeScreenOnly={!isSidebarPresent}>
+        {isSidebarPresent ? (
+          <SidebarComponent />
+        ) : (
+          <FillerText>
+            <ClusterEditHelpCopy />
+          </FillerText>
+        )}
+      </InsetPanel>
       <OutsetFiller />
     </>
   );

--- a/app/routes/_layout.environments.$environmentName.edit.tsx
+++ b/app/routes/_layout.environments.$environmentName.edit.tsx
@@ -10,6 +10,7 @@ import type { SherlockEnvironmentV3 } from "@sherlock-js-client/sherlock";
 import {
   ClustersApi,
   EnvironmentsApi,
+  RolesApi,
   UsersApi,
 } from "@sherlock-js-client/sherlock";
 import { useState } from "react";
@@ -59,6 +60,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
         (users) => users.sort(makeUserSorter(getUserEmail(request))),
         errorResponseThrower,
       ),
+    new RolesApi(SherlockConfiguration)
+      .apiRolesV3Get({}, handleIAP(request))
+      .catch(errorResponseThrower),
   ]);
 }
 
@@ -90,7 +94,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 export const ErrorBoundary = PanelErrorBoundary;
 
 export default function Route() {
-  const [clusters, users] = useLoaderData<typeof loader>();
+  const [clusters, users, roles] = useLoaderData<typeof loader>();
   const errorInfo = useActionData<typeof action>();
   const { environment } = useEnvironmentContext();
 
@@ -118,6 +122,7 @@ export default function Route() {
             setSidebarFilterText={setSidebarFilterText}
             clusters={clusters}
             users={users}
+            roles={roles}
             environment={errorInfo?.formState || environment}
             defaultCluster={defaultCluster}
             setDefaultCluster={setDefaultCluster}

--- a/app/routes/_layout.environments.new.tsx
+++ b/app/routes/_layout.environments.new.tsx
@@ -9,6 +9,7 @@ import type { SherlockEnvironmentV3 } from "@sherlock-js-client/sherlock";
 import {
   ClustersApi,
   EnvironmentsApi,
+  RolesApi,
   UsersApi,
 } from "@sherlock-js-client/sherlock";
 import { useMemo, useState } from "react";
@@ -72,6 +73,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
         (users) => users.sort(makeUserSorter(selfUserEmail)),
         errorResponseThrower,
       ),
+    new RolesApi(SherlockConfiguration)
+      .apiRolesV3Get({}, handleIAP(request))
+      .catch(errorResponseThrower),
     preconfiguredLifecycle,
   ]);
 }
@@ -144,7 +148,7 @@ export async function action({ request }: ActionFunctionArgs) {
 export const ErrorBoundary = PanelErrorBoundary;
 
 export default function Route() {
-  const [userEmail, clusters, users, preconfiguredLifecycle] =
+  const [userEmail, clusters, users, roles, preconfiguredLifecycle] =
     useLoaderData<typeof loader>();
   const errorInfo = useActionData<typeof action>();
   const { environments } = useEnvironmentsContext();
@@ -326,6 +330,7 @@ export default function Route() {
                 setSidebarFilterText={setSidebarFilterText}
                 clusters={clusters}
                 users={users}
+                roles={roles}
                 environment={errorInfo?.formState}
                 creating={true}
                 templateInUse={lifecycle === "dynamic"}


### PR DESCRIPTION
![Screenshot 2024-07-11 at 12 44 45 PM](https://github.com/broadinstitute/beehive/assets/29168264/a79b7816-e6ce-4955-a82b-d4e256156b7f)

![Screenshot 2024-07-11 at 12 43 38 PM](https://github.com/broadinstitute/beehive/assets/29168264/623947c9-d125-4891-9921-e410e033a102)

Borrows Chelsea's Role select sidebar components. Easy for Environment since that edit panel already had sidebar capability; added sidebar capability to Cluster.

A subsequent PR will remove the suitability toggle before Sherlock removes that capability.

## Testing

Manually against dev. The only issue is actually a Sherlock-side issue with a fix proposed in https://github.com/broadinstitute/sherlock/pull/603.

## Risk

Low