### PR TITLE
[DDO-3787] Fix two more broken links

### DIFF
--- a/app/routes/_layout.environments.$environmentName.deploy-hooks.github-actions.$id.test-run.tsx
+++ b/app/routes/_layout.environments.$environmentName.deploy-hooks.github-actions.$id.test-run.tsx
@@ -1,0 +1,38 @@
+import { type ActionFunctionArgs } from "@remix-run/node";
+import type { MetaFunction, Params } from "@remix-run/react";
+import { NavLink, useActionData } from "@remix-run/react";
+import { PanelErrorBoundary } from "~/errors/components/error-boundary";
+import { DeployHookTestPanel } from "~/features/sherlock/deploy-hooks/test-run/deploy-hook-test-panel";
+import { testGithubActionsDeployHookAction } from "~/features/sherlock/deploy-hooks/test-run/test-github-actions-deploy-hook-action.server";
+
+export const handle = {
+  breadcrumb: (params: Readonly<Params<string>>) => (
+    <NavLink
+      to={`/environments/${params.environmentName}/deploy-hooks/github-actions/${params.id}/test-run`}
+    >
+      Test
+    </NavLink>
+  ),
+};
+
+export const meta: MetaFunction = ({ params }) => [
+  {
+    title: `${params.environmentName}/${params.chartName} - Environment - Deploy Hooks - GitHub Actions Hook - Test`,
+  },
+];
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  return testGithubActionsDeployHookAction(
+    request,
+    `/environments/${params.environmentName}/deploy-hooks/github-actions/${params.id}/test-run`,
+    params.id ?? "",
+  );
+}
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export default function Route() {
+  const errorInfo = useActionData<typeof action>();
+
+  return <DeployHookTestPanel errorInfo={errorInfo} type="GitHub Actions" />;
+}

--- a/app/routes/_layout.environments.$environmentName.deploy-hooks.slack.$id.test-run.tsx
+++ b/app/routes/_layout.environments.$environmentName.deploy-hooks.slack.$id.test-run.tsx
@@ -1,0 +1,38 @@
+import { type ActionFunctionArgs } from "@remix-run/node";
+import type { MetaFunction, Params } from "@remix-run/react";
+import { NavLink, useActionData } from "@remix-run/react";
+import { PanelErrorBoundary } from "~/errors/components/error-boundary";
+import { DeployHookTestPanel } from "~/features/sherlock/deploy-hooks/test-run/deploy-hook-test-panel";
+import { testSlackDeployHookAction } from "~/features/sherlock/deploy-hooks/test-run/test-slack-deploy-hook-action.server";
+
+export const handle = {
+  breadcrumb: (params: Readonly<Params<string>>) => (
+    <NavLink
+      to={`/environments/${params.environmentName}/deploy-hooks/slack/${params.id}/test-run`}
+    >
+      Test
+    </NavLink>
+  ),
+};
+
+export const meta: MetaFunction = ({ params }) => [
+  {
+    title: `${params.environmentName}/${params.chartName} - Environment - Deploy Hooks - Slack Hook - Test`,
+  },
+];
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  return testSlackDeployHookAction(
+    request,
+    `/environments/${params.environmentName}/deploy-hooks/slack/${params.id}/test-run`,
+    params.id ?? "",
+  );
+}
+
+export const ErrorBoundary = PanelErrorBoundary;
+
+export default function Route() {
+  const errorInfo = useActionData<typeof action>();
+
+  return <DeployHookTestPanel errorInfo={errorInfo} type="Slack" />;
+}


### PR DESCRIPTION
As part of #511 I realized that I forgot to add UI pages for testing environment-level deploy hooks. I guess no one's noticed because folks don't really make those much, it's just been me for Slacks. Whatever, not that much code to add the pages and the API already exists.

## Testing

Manual against prod, I used dry-run which still exercises the POST

## Risk

Low