### PR TITLE
[DDO-3785] Remove references to suitability

### DIFF
--- a/app/features/sherlock/clusters/edit/cluster-editable-fields.tsx
+++ b/app/features/sherlock/clusters/edit/cluster-editable-fields.tsx
@@ -18,9 +18,6 @@ export interface ClusterEditableFieldsProps {
 export const ClusterEditableFields: React.FunctionComponent<
   ClusterEditableFieldsProps & SetsSidebarProps
 > = ({ setSidebarFilterText, setSidebar, cluster, roles }) => {
-  const [requiresSuitability, setRequiresSuitability] = useState(
-    cluster?.requiresSuitability === true ? "true" : "false",
-  );
   const [requiredRole, setRequiredRole] = useState(
     cluster?.requiredRole != null ? cluster.requiredRole : "",
   );
@@ -86,26 +83,6 @@ export const ClusterEditableFields: React.FunctionComponent<
           defaultValue={cluster?.location}
         />
       </label>
-      <div>
-        <h2 className="font-light text-2xl text-color-header-text">
-          Require Suitability?
-        </h2>
-        <p>
-          DevOps's systems can require production-suitability to <b>modify</b>{" "}
-          this cluster (doesn't affect access or cloud provider permissions).
-        </p>
-        <EnumInputSelect
-          name="requiresSuitability"
-          className="grid grid-cols-2 mt-2"
-          fieldValue={requiresSuitability}
-          setFieldValue={setRequiresSuitability}
-          enums={[
-            ["Yes", "true"],
-            ["No", "false"],
-          ]}
-          {...ClusterColors}
-        />
-      </div>
       <div>
         <h2 className="font-light text-2xl text-color-header-text">
           Require Role?

--- a/app/features/sherlock/environments/edit/environment-editable-fields.tsx
+++ b/app/features/sherlock/environments/edit/environment-editable-fields.tsx
@@ -59,11 +59,6 @@ export const EnvironmentEditableFields: React.FunctionComponent<
         // effort than we need right now.
         "true",
   );
-  const [requiresSuitability, setRequiresSuitability] = useState(
-    environment?.requiresSuitability != null
-      ? environment.requiresSuitability.toString()
-      : "false",
-  );
   const [requiredRole, setRequiredRole] = useState(
     environment?.requiredRole != null ? environment.requiredRole : "",
   );
@@ -114,27 +109,6 @@ export const EnvironmentEditableFields: React.FunctionComponent<
           />
         </div>
       )}
-      <div>
-        <h2 className="font-light text-2xl text-color-header-text">
-          Require Suitability?
-        </h2>
-        <p>
-          DevOps's systems can require production-suitability to{" "}
-          <b className="font-semibold">modify</b> this environment (doesn't
-          affect access).
-        </p>
-        <EnumInputSelect
-          name="requiresSuitability"
-          className="grid grid-cols-2 mt-2"
-          fieldValue={requiresSuitability}
-          setFieldValue={setRequiresSuitability}
-          enums={[
-            ["Yes", "true"],
-            ["No", "false"],
-          ]}
-          {...EnvironmentColors}
-        />
-      </div>
       <div>
         <h2 className="font-light text-2xl text-color-header-text">
           Require Role?

--- a/app/routes/_layout.clusters.$clusterName.edit.tsx
+++ b/app/routes/_layout.clusters.$clusterName.edit.tsx
@@ -54,7 +54,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const formData = await request.formData();
   const clusterRequest: SherlockClusterV3 = {
     ...formDataToObject(formData, false),
-    requiresSuitability: formData.get("requiresSuitability") === "true",
   };
 
   return new ClustersApi(SherlockConfiguration)

--- a/app/routes/_layout.clusters.new.tsx
+++ b/app/routes/_layout.clusters.new.tsx
@@ -51,7 +51,6 @@ export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const clusterRequest: SherlockClusterV3 = {
     ...formDataToObject(formData, true),
-    requiresSuitability: formData.get("requiresSuitability") === "true",
   };
 
   return new ClustersApi(SherlockConfiguration)

--- a/app/routes/_layout.environments.$environmentName.edit.tsx
+++ b/app/routes/_layout.environments.$environmentName.edit.tsx
@@ -72,7 +72,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const formData = await request.formData();
   const environmentRequest: SherlockEnvironmentV3 = {
     ...formDataToObject(formData, false),
-    requiresSuitability: formData.get("requiresSuitability") === "true",
     namePrefixesDomain: formData.get("namePrefixesDomain") === "true",
     preventDeletion: formData.get("preventDeletion") === "true",
     enableJanitor: formData.get("enableJanitor") === "true",

--- a/app/routes/_layout.environments.new.tsx
+++ b/app/routes/_layout.environments.new.tsx
@@ -91,7 +91,6 @@ export async function action({ request }: ActionFunctionArgs) {
     ...formDataToObject(formData, true),
     autoPopulateChartReleases:
       formData.get("autoPopulateChartReleases") === "true",
-    requiresSuitability: formData.get("requiresSuitability") === "true",
     namePrefixesDomain: formData.get("namePrefixesDomain") === "true",
     preventDeletion: formData.get("preventDeletion") === "true",
     enableJanitor: formData.get("enableJanitor") === "true",


### PR DESCRIPTION
...for environments and clusters, not for roles where it's still a thing.

Requires https://github.com/broadinstitute/thelma/pull/309 first to be safe. Technically the field is unused already.

## Testing

Locally

![Screenshot 2024-07-31 at 4 09 56 PM](https://github.com/user-attachments/assets/925d9587-e8ad-41bd-bae0-299641d3507d)

## Risk

Low