### PR TITLE
[DDO-3908] Force-update cookie dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6640,9 +6640,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": ">=20.17.0"
   },
   "overrides": {
+    "cookie": "^0.7.0",
     "@remix-run/node": "$@remix-run/node",
     "@remix-run/react": "$@remix-run/react",
     "@remix-run/serve": "$@remix-run/serve",


### PR DESCRIPTION
https://github.com/broadinstitute/beehive/security/dependabot/50 has a better description of what's going on here than I could write. This fixes it.

## Testing

Booted it up locally. Cookie didn't fall over. Close enough.

## Risk

Low. I looked at the changelog myself.