### PR TITLE
[DDO-3902] Add service banner bucket edit field for environments

### DIFF
--- a/app/features/sherlock/environments/edit/environment-editable-fields.tsx
+++ b/app/features/sherlock/environments/edit/environment-editable-fields.tsx
@@ -314,6 +314,26 @@ export const EnvironmentEditableFields: React.FunctionComponent<
           />
         </div>
       )}
+      <label>
+        <h2 className="font-light text-2xl text-color-header-text">
+          Service Banner Bucket
+        </h2>
+        <p>
+          The GCS bucket containing the Terra UI banner files. If empty, the
+          banner cannot be set.
+        </p>
+        <TextField
+          name="serviceBannerBucket"
+          placeholder={
+            creating
+              ? templateInUse
+                ? "(defaults to template's value)"
+                : "(can be left empty)"
+              : "(can be left empty)"
+          }
+          defaultValue={creating ? undefined : environment?.serviceBannerBucket}
+        />
+      </label>
     </div>
   );
 };

--- a/app/features/sherlock/environments/edit/environment-editable-fields.tsx
+++ b/app/features/sherlock/environments/edit/environment-editable-fields.tsx
@@ -325,10 +325,8 @@ export const EnvironmentEditableFields: React.FunctionComponent<
         <TextField
           name="serviceBannerBucket"
           placeholder={
-            creating
-              ? templateInUse
-                ? "(defaults to template's value)"
-                : "(can be left empty)"
+            creating && templateInUse
+              ? "(defaults to template's value)"
               : "(can be left empty)"
           }
           defaultValue={creating ? undefined : environment?.serviceBannerBucket}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@remix-run/node": "^v2.12.0",
         "@remix-run/react": "^v2.12.0",
         "@remix-run/serve": "^v2.12.0",
-        "@sherlock-js-client/sherlock": "^1.5.49",
+        "@sherlock-js-client/sherlock": "^1.6.15",
         "lucide-react": "^0.439.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4461,9 +4461,9 @@
       "dev": true
     },
     "node_modules/@sherlock-js-client/sherlock": {
-      "version": "1.5.49",
-      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-1.5.49.tgz",
-      "integrity": "sha512-z3G5BrGQ597fKuQnoUSMjfXwiDBDEpIaBX/ucpnPdg32olgk16YXp42gVrZeMCqZq3cTHk2jPRkDu0UGDHftpQ=="
+      "version": "1.6.15",
+      "resolved": "https://us-central1-npm.pkg.dev/dsp-artifact-registry/sherlock-js-client/@sherlock-js-client/sherlock/-/@sherlock-js-client/sherlock-1.6.15.tgz",
+      "integrity": "sha512-uzMhR8+FR7QQTsdxQqT3Xkj4IJtq3GnRZbvm+tuMvBMQBSVFmQx0+nLo6+Qtwri/q7GjGOUHb9BTKC8Ip8dGuA=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@remix-run/node": "^v2.12.0",
     "@remix-run/react": "^v2.12.0",
     "@remix-run/serve": "^v2.12.0",
-    "@sherlock-js-client/sherlock": "^1.5.49",
+    "@sherlock-js-client/sherlock": "^1.6.15",
     "lucide-react": "^0.439.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
# What

As outlined in [DDO-3902](https://broadworkbench.atlassian.net/browse/DDO-3902), adds a Beehive environment edit field for the Terra service banner bucket. Setting the bucket will allow for future versions of Sherlock to update the Terra UI GCS banner file which corresponds to the Terra UI banner. For now, all this does is update the database, so my plan is to merge this PR but have it deployed to prod Beehive only after the Sherlock feature goes out.

# Screenshots

Creating a template
<img width="447" alt="Captura de pantalla 2024-11-21 a la(s) 10 35 33" src="https://github.com/user-attachments/assets/0012a7a7-b6d0-4a36-8750-10c47cd72a7a">

Creating a BEE
<img width="443" alt="Captura de pantalla 2024-11-21 a la(s) 10 55 42" src="https://github.com/user-attachments/assets/6cf51b18-e338-4671-a38e-16b275b38195">

Updating a template or BEE or viewing the "Edit Metadata" panel
<img width="473" alt="Captura de pantalla 2024-11-21 a la(s) 10 37 44" src="https://github.com/user-attachments/assets/66121568-e362-4d22-b4db-b13c5cd274e0">

[DDO-3902]: https://broadworkbench.atlassian.net/browse/DDO-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Testing
I set beehive-dev to this branch and tested the feature, verifying the changes in sherlock-dev's db.