### PR TITLE
Override turbo-stream to 3.0.0 to fix CVE-2026-34077 (CTM-540)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18004,10 +18004,10 @@
       "dev": true
     },
     "node_modules/turbo-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
-      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==",
-      "license": "ISC"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-3.0.0.tgz",
+      "integrity": "sha512-cD7s7mh0XtUa+sE5Ej1ShRrWGKiAZ1X/l4clV7Dyg4A+u9jf2pbTTKDApeW0B7Za5o/tNCGzNTLFHBAVxeQC6g==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "path-to-regexp": "^0.1.13",
     "jws": "^4.0.1",
     "qs": "^6.14.2",
+    "turbo-stream": "3.0.0",
     "undici": "^6.24.0",
     "uuid": "^11.1.1",
     "@remix-run/node": "$@remix-run/node",


### PR DESCRIPTION
## Summary
Fixes CTM-540: turbo-stream 2.4.1 (bundled via @remix-run/server-runtime) is vulnerable to CVE-2026-34077, a DoS via unbounded resource allocation when decoding nested structures. Adds an `overrides` entry forcing turbo-stream to 3.0.0, the first patched version.

## Risk assessment
turbo-stream 3.0.0 has a breaking change (new encoding format), but @remix-run/server-runtime only imports turbo-stream inside `single-fetch.ts`, gated behind Remix's opt-in Single Fetch future flag. Beehive doesn't enable that flag anywhere (confirmed in vite.config.ts and via the Remix future-flag warnings printed during test runs), so this code path isn't exercised, the override should have no runtime effect beyond removing the vulnerable dependency version.

## Verification
- [x] `npm run build` succeeds
- [x] `npm test` passes (10/10)
- [x] `npm run typecheck` output is identical to main (pre-existing errors, unrelated)
- [x] `npm ls turbo-stream` confirms 3.0.0 resolved everywhere