### PR TITLE
Override undici to 6.27.0 to fix CVE-2026-12151 (CTM-555)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18104,9 +18104,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jws": "^4.0.1",
     "qs": "^6.14.2",
     "turbo-stream": "3.0.0",
-    "undici": "^6.24.0",
+    "undici": "^6.27.0",
     "uuid": "^11.1.1",
     "@remix-run/node": "$@remix-run/node",
     "@remix-run/react": "$@remix-run/react",


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-555

## Summary
Fixes CTM-555: undici 6.26.0 (bundled via @remix-run/node) is vulnerable to CVE-2026-12151. Fixed in 6.27.0. Bumps the existing `overrides` entry for undici from ^6.24.0 to ^6.27.0.

## Verification
- [x] `npm run build` succeeds
- [x] `npm test` passes (10/10)
- [x] `npm run typecheck` output is identical to main (pre-existing errors, unrelated)
- [x] `npm ls undici` confirms 6.27.0 resolved everywhere